### PR TITLE
[MERGE] Improve Sonar test coverage scope

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,6 +8,10 @@ on:
       - 'scripts/deploy-backend.sh'
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'scripts/deploy-backend.sh'
+      - '.github/workflows/backend.yml'
 
 permissions:
   contents: write
@@ -75,7 +79,7 @@ jobs:
           DJANGO_ALLOWED_HOSTS: localhost
         run: |
           cd backend
-          coverage run --rcfile=.coveragerc manage.py test api
+          coverage run --rcfile=.coveragerc manage.py test
           coverage report
           coverage xml
           coverage json -o coverage.json
@@ -188,10 +192,11 @@ jobs:
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
             -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_BACKEND }}
-            -Dsonar.sources=api,config,file_processing
-            -Dsonar.exclusions=**/tests.py,**/tests/**/*.py,**/test_*.py,**/*_test.py
-            -Dsonar.tests=api,file_processing
-            -Dsonar.test.inclusions=**/tests.py,**/tests/**/*.py,**/test_*.py,**/*_test.py
+            -Dsonar.sources=api,llm,file_processing
+            -Dsonar.tests=api,llm,file_processing
+            -Dsonar.test.inclusions=**/tests/**/*.py,**/tests.py,**/test_*.py,**/*_test.py
+            -Dsonar.exclusions=**/migrations/**
+            -Dsonar.coverage.exclusions=**/tests/**,**/tests.py,**/test_*.py,**/*_test.py,**/migrations/**
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.qualitygate.wait=true
             -Dsonar.qualitygate.timeout=300

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,10 @@ on:
       - 'scripts/deploy-frontend.sh'
   pull_request:
     branches: [main]
+    paths:
+      - 'frontend/**'
+      - 'scripts/deploy-frontend.sh'
+      - '.github/workflows/frontend.yml'
 
 permissions:
   contents: write
@@ -153,7 +157,7 @@ jobs:
             -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_FRONTEND }}
             -Dsonar.sources=src
             -Dsonar.tests=tests
-            -Dsonar.test.inclusions=tests/**/*.{test,spec}.{ts,tsx},tests/setup.ts,tests/mocks/**/*.ts
+            -Dsonar.test.inclusions=tests/**/*.{test,spec}.{js,jsx,ts,tsx},tests/setup.{js,ts},tests/mocks/**/*.{js,ts}
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
             -Dsonar.qualitygate.wait=true
             -Dsonar.qualitygate.timeout=300

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -2,8 +2,11 @@
 branch = True
 source =
     api
+    file_processing
 omit =
     */migrations/*
+    */tests/*
+    */tests.py
 
 [report]
 show_missing = True


### PR DESCRIPTION
<!-- Use [**Conventional Commits**](https://www.conventionalcommits.org/en/v1.0.0/) format for PR titles:

```
<type>(<scope>): <description>
```

### **Common Types:**

* `feat`: New feature
* `fix`: Bug fix
* `docs`: Documentation changes
* `style`: Code style changes (formatting, no logic changes)
* `refactor`: Code refactoring
* `test`: Adding or updating tests
* `chore`: Maintenance tasks, dependency updates

### **Description Field:**

* Recommended to start a \<description\> with a verb (add, resolve, update, etc.)

### **Examples:**

* `feat(auth): add OAuth2 login integration`
* `fix(api): resolve null pointer exception in user service`
* `docs(readme): update installation instructions`
* `refactor(database): optimize query performance`
* `feat(BE): add vector DB connection`
* `fix(FE): login redirection` -->

## Summary


This pull request updates the backend and frontend CI/CD workflows and related configuration files to improve test coverage, SonarCloud analysis, and workflow efficiency. The main changes include refining the paths that trigger workflows, expanding code coverage and analysis to additional modules, and improving test and coverage exclusions.

**Backend workflow and coverage improvements:**

* The backend GitHub Actions workflow (`.github/workflows/backend.yml`) now only runs on pull requests that modify backend-related files, deployment scripts, or the workflow file itself, reducing unnecessary workflow runs.
* The test command now runs all Django tests instead of just those in the `api` app, increasing test coverage.
* SonarCloud analysis is expanded to include the `llm` module, with refined exclusions to ignore migration and test files for both code analysis and coverage. Coverage exclusion patterns have been improved for more accurate reporting.
* The `.coveragerc` configuration now includes the `file_processing` module in coverage and explicitly omits test and migration files, aligning coverage reporting with SonarCloud configuration.

**Frontend workflow and SonarCloud improvements:**

* The frontend workflow (`.github/workflows/frontend.yml`) now only runs on pull requests affecting frontend files, deployment scripts, or the workflow file, making workflow execution more efficient.
* SonarCloud test inclusion patterns have been expanded to cover both JavaScript and TypeScript test files, as well as setup and mock files, improving test detection and coverage analysis.

## How to Test

<!--- Steps to manually test or verify functionality-->

1. Check Sonar now working correctly on each PR

## Related Issues

#6 

## Author Checklist

- [x] Code follows team coding standards and style guide
- [x] Self-reviewed the code changes
- [ ] Added/updated tests for new functionality
- [ ] All tests pass locally
- [ ] Code is properly documented
- [x] Synced with latest `main` branch
- [x] PR title follows conventional commit format
- [ ] Meaningful commit messages used

## Additional Notes

<!-- Any additional context, screenshots, or information reviewers should know -->

## Type of task

<!--- Please checklist options that are relevant -->

- [ ] Data Processing (for tasks involving data handling or manipulation)
- [ ] Model Training (for tasks involving model training)
- [ ] API Development (for developing or serving model via API)
- [ ] UI Development (for developing or improving user interface)
- [ ] Testing (for writing or updating tests)
- [ ] Debugging (for fixing errors or investigating issues)
- [x] Refactor (for code improvements without changing functionality)
- [ ] Performance Improvement / Optimization (for optimizations related to speed or efficiency)
- [ ] Security (for tasks related to security updates or patches)
- [ ] Documentation (for updating or improving documentation)
- [ ] Monitoring (for adding or updating monitoring capabilities)
- [ ] All

## Reviewer(s)

<!--- Please add the names or GitHub usernames of the reviewers -->

- [ ] @Staphlerr 
