### PR TITLE
refactor: validation for word document more than 100 pages

### DIFF
--- a/.github/badges/backend-coverage.svg
+++ b/.github/badges/backend-coverage.svg
@@ -1,20 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="144" height="20" role="img" aria-label="backend coverage: 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="137" height="20" role="img" aria-label="backend coverage: 96%">
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <clipPath id="r">
-    <rect width="144" height="20" rx="3" fill="#fff"/>
+    <rect width="137" height="20" rx="3" fill="#fff"/>
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="106" height="20" fill="#555"/>
-    <rect x="106" width="38" height="20" fill="hsl(120, 85%, 40%)"/>
-    <rect width="144" height="20" fill="url(#s)"/>
+    <rect x="106" width="31" height="20" fill="hsl(115, 85%, 40%)"/>
+    <rect width="137" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="53" y="15" fill="#010101" fill-opacity=".3">backend coverage</text>
     <text x="53" y="14">backend coverage</text>
-    <text x="125" y="15" fill="#010101" fill-opacity=".3">100%</text>
-    <text x="125" y="14">100%</text>
+    <text x="121" y="15" fill="#010101" fill-opacity=".3">96%</text>
+    <text x="121" y="14">96%</text>
   </g>
 </svg>

--- a/.github/badges/backend-coverage.svg
+++ b/.github/badges/backend-coverage.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="137" height="20" role="img" aria-label="backend coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="137" height="20" role="img" aria-label="backend coverage: 99%">
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -8,13 +8,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="106" height="20" fill="#555"/>
-    <rect x="106" width="31" height="20" fill="hsl(116, 85%, 40%)"/>
+    <rect x="106" width="31" height="20" fill="hsl(118, 85%, 40%)"/>
     <rect width="137" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="53" y="15" fill="#010101" fill-opacity=".3">backend coverage</text>
     <text x="53" y="14">backend coverage</text>
-    <text x="121" y="15" fill="#010101" fill-opacity=".3">97%</text>
-    <text x="121" y="14">97%</text>
+    <text x="121" y="15" fill="#010101" fill-opacity=".3">99%</text>
+    <text x="121" y="14">99%</text>
   </g>
 </svg>

--- a/.github/badges/backend-coverage.svg
+++ b/.github/badges/backend-coverage.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="137" height="20" role="img" aria-label="backend coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="137" height="20" role="img" aria-label="backend coverage: 97%">
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -8,13 +8,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="106" height="20" fill="#555"/>
-    <rect x="106" width="31" height="20" fill="hsl(115, 85%, 40%)"/>
+    <rect x="106" width="31" height="20" fill="hsl(116, 85%, 40%)"/>
     <rect width="137" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="53" y="15" fill="#010101" fill-opacity=".3">backend coverage</text>
     <text x="53" y="14">backend coverage</text>
-    <text x="121" y="15" fill="#010101" fill-opacity=".3">96%</text>
-    <text x="121" y="14">96%</text>
+    <text x="121" y="15" fill="#010101" fill-opacity=".3">97%</text>
+    <text x="121" y="14">97%</text>
   </g>
 </svg>

--- a/.github/badges/backend-coverage.svg
+++ b/.github/badges/backend-coverage.svg
@@ -1,20 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="137" height="20" role="img" aria-label="backend coverage: 99%">
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="20" role="img" aria-label="backend coverage: 100%">
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <clipPath id="r">
-    <rect width="137" height="20" rx="3" fill="#fff"/>
+    <rect width="144" height="20" rx="3" fill="#fff"/>
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="106" height="20" fill="#555"/>
-    <rect x="106" width="31" height="20" fill="hsl(118, 85%, 40%)"/>
-    <rect width="137" height="20" fill="url(#s)"/>
+    <rect x="106" width="38" height="20" fill="hsl(120, 85%, 40%)"/>
+    <rect width="144" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="53" y="15" fill="#010101" fill-opacity=".3">backend coverage</text>
     <text x="53" y="14">backend coverage</text>
-    <text x="121" y="15" fill="#010101" fill-opacity=".3">99%</text>
-    <text x="121" y="14">99%</text>
+    <text x="125" y="15" fill="#010101" fill-opacity=".3">100%</text>
+    <text x="125" y="14">100%</text>
   </g>
 </svg>

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -12,9 +12,6 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 from pathlib import Path
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -12,6 +12,9 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 from pathlib import Path
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -147,14 +150,12 @@ MEDIA_ROOT = os.environ.get("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"
 
 
-UPLOAD_TEMP_DIR = os.path.join(MEDIA_ROOT, 'uploads', 'tmp')
+UPLOAD_TEMP_DIR = os.path.join(MEDIA_ROOT, "uploads", "tmp")
 CSV_EXPORT_DIR = os.environ.get(
-    'CSV_EXPORT_DIR',
-    os.path.join(MEDIA_ROOT, 'exports', 'csv')
+    "CSV_EXPORT_DIR", os.path.join(MEDIA_ROOT, "exports", "csv")
 )
 EXCEL_EXPORT_DIR = os.environ.get(
-    'EXCEL_EXPORT_DIR',
-    os.path.join(MEDIA_ROOT, 'exports', 'excel')
+    "EXCEL_EXPORT_DIR", os.path.join(MEDIA_ROOT, "exports", "excel")
 )
 
 # Default primary key field type

--- a/backend/file_processing/services/word_validation_service.py
+++ b/backend/file_processing/services/word_validation_service.py
@@ -13,6 +13,13 @@ MAX_WORD_PAGES = 100
 DOCX_CHARS_PER_PAGE_ESTIMATE = 2500
 DOCX_WORDS_PER_PAGE_ESTIMATE = 350
 DOCX_BLOCKS_PER_PAGE_ESTIMATE = 35
+DOCX_DEFAULT_PAGE_WIDTH_INCH = 8.5
+DOCX_DEFAULT_PAGE_HEIGHT_INCH = 11.0
+DOCX_DEFAULT_MARGIN_INCH = 1.0
+DOCX_IMAGE_DENSE_THRESHOLD = 0.35
+DOCX_IMAGE_PAGE_AREA_FACTOR = 0.65
+DOCX_IMAGE_MEDIUM_AREA_INCH2 = 6.0
+DOCX_IMAGE_SMALL_AREA_INCH2 = 1.5
 WORD_CORRUPT_ERROR = "Word file is corrupt or has an invalid structure."
 WORD_PROTECTED_ERROR = "Word file is password-protected."
 OLE_SIGNATURE = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
@@ -172,7 +179,9 @@ def check_docx_structure(uploaded_file: Any) -> Tuple[bool, Any]:
         uploaded_file.seek(0)
 
 
-def extract_docx_page_count(archive: zipfile.ZipFile, docx_bytes: Optional[bytes] = None) -> int:
+def extract_docx_page_count(
+    archive: zipfile.ZipFile, docx_bytes: Optional[bytes] = None
+) -> int:
     app_pages = 0
     try:
         app_xml = archive.read("docProps/app.xml")
@@ -208,6 +217,10 @@ def _estimate_docx_pages_with_python_docx(docx_bytes: Optional[bytes]) -> int:
     table_row_count = 0
     word_count = 0
     explicit_page_breaks = 0
+    image_count = 0
+    total_image_area = 0.0
+
+    usable_page_area = _estimate_docx_usable_page_area(document)
 
     for paragraph in document.paragraphs:
         paragraph_count += 1
@@ -227,6 +240,21 @@ def _estimate_docx_pages_with_python_docx(docx_bytes: Optional[bytes]) -> int:
                         break
                 if break_type == "page":
                     explicit_page_breaks += 1
+
+    try:
+        body_node = document.element.body
+    except Exception:
+        body_node = None
+
+    if body_node is not None:
+        for node in body_node.iter():
+            node_name = _local_name(node.tag)
+            if node_name in {"drawing", "pict", "object"}:
+                image_count += 1
+            elif node_name == "extent":
+                cx, cy = _extract_extent_inches(node)
+                if cx > 0 and cy > 0:
+                    total_image_area += cx * cy
 
     for table in document.tables:
         for row in table.rows:
@@ -256,7 +284,130 @@ def _estimate_docx_pages_with_python_docx(docx_bytes: Optional[bytes]) -> int:
             1, math.ceil(block_count / DOCX_BLOCKS_PER_PAGE_ESTIMATE)
         )
 
-    return max(break_estimate, section_estimate, word_estimate, structure_estimate)
+    image_estimate = _estimate_pages_from_images(
+        image_count=image_count,
+        total_image_area=total_image_area,
+        usable_page_area=usable_page_area,
+    )
+
+    return max(
+        break_estimate,
+        section_estimate,
+        word_estimate,
+        structure_estimate,
+        image_estimate,
+    )
+
+
+def _estimate_docx_usable_page_area(document: Document) -> float:
+    try:
+        section = document.sections[0]
+    except Exception:
+        section = None
+
+    if section is None:
+        width = DOCX_DEFAULT_PAGE_WIDTH_INCH
+        height = DOCX_DEFAULT_PAGE_HEIGHT_INCH
+        left = right = top = bottom = DOCX_DEFAULT_MARGIN_INCH
+    else:
+        width = _safe_section_length_inches(
+            section, "page_width", DOCX_DEFAULT_PAGE_WIDTH_INCH
+        )
+        height = _safe_section_length_inches(
+            section, "page_height", DOCX_DEFAULT_PAGE_HEIGHT_INCH
+        )
+        left = _safe_section_length_inches(
+            section, "left_margin", DOCX_DEFAULT_MARGIN_INCH
+        )
+        right = _safe_section_length_inches(
+            section, "right_margin", DOCX_DEFAULT_MARGIN_INCH
+        )
+        top = _safe_section_length_inches(
+            section, "top_margin", DOCX_DEFAULT_MARGIN_INCH
+        )
+        bottom = _safe_section_length_inches(
+            section, "bottom_margin", DOCX_DEFAULT_MARGIN_INCH
+        )
+
+    usable_width = max(1.0, width - left - right)
+    usable_height = max(1.0, height - top - bottom)
+    return usable_width * usable_height
+
+
+def _estimate_pages_from_images(
+    image_count: int, total_image_area: float, usable_page_area: float
+) -> int:
+    if image_count <= 0:
+        return 0
+
+    area_based_estimate = 0
+    if total_image_area > 0 and usable_page_area > 0:
+        area_based_estimate = max(
+            1,
+            math.ceil(
+                total_image_area / (usable_page_area * DOCX_IMAGE_PAGE_AREA_FACTOR)
+            ),
+        )
+
+    image_count_based_estimate = 0
+    if total_image_area > 0 and usable_page_area > 0:
+        avg_image_area = total_image_area / image_count
+        if avg_image_area >= usable_page_area * DOCX_IMAGE_DENSE_THRESHOLD:
+            image_count_based_estimate = image_count
+        elif avg_image_area >= DOCX_IMAGE_MEDIUM_AREA_INCH2:
+            image_count_based_estimate = max(1, math.ceil(image_count / 2))
+        elif avg_image_area >= DOCX_IMAGE_SMALL_AREA_INCH2:
+            image_count_based_estimate = max(1, math.ceil(image_count / 3))
+        else:
+            image_count_based_estimate = max(1, math.ceil(image_count / 6))
+    else:
+        image_count_based_estimate = max(1, math.ceil(image_count / 6))
+
+    return max(area_based_estimate, image_count_based_estimate)
+
+
+def _extract_extent_inches(node: Any) -> Tuple[float, float]:
+    # wp:extent stores width/height in EMU; values are used to estimate page occupancy.
+    cx_emu = 0
+    cy_emu = 0
+
+    for key, value in getattr(node, "attrib", {}).items():
+        key_name = str(key)
+        if key_name.endswith("cx"):
+            try:
+                cx_emu = int(value)
+            except Exception:
+                cx_emu = 0
+        elif key_name.endswith("cy"):
+            try:
+                cy_emu = int(value)
+            except Exception:
+                cy_emu = 0
+
+    return _emu_to_inches(cx_emu, 0.0), _emu_to_inches(cy_emu, 0.0)
+
+
+def _safe_section_length_inches(
+    section: Any, attribute_name: str, default: float
+) -> float:
+    try:
+        raw_value = getattr(section, attribute_name)
+    except Exception:
+        return default
+
+    return _emu_to_inches(raw_value, default)
+
+
+def _emu_to_inches(value: Any, default: float) -> float:
+    try:
+        numeric_value = float(value)
+    except Exception:
+        return default
+
+    if numeric_value <= 0:
+        return default
+
+    return numeric_value / 914400.0
 
 
 def _estimate_docx_pages_from_document_xml(document_xml: bytes) -> int:
@@ -306,7 +457,9 @@ def _estimate_docx_pages_from_document_xml(document_xml: bytes) -> int:
 
     text_estimate = 0
     if text_char_count > 0:
-        text_estimate = max(1, math.ceil(text_char_count / DOCX_CHARS_PER_PAGE_ESTIMATE))
+        text_estimate = max(
+            1, math.ceil(text_char_count / DOCX_CHARS_PER_PAGE_ESTIMATE)
+        )
 
     return max(marker_estimate, text_estimate)
 

--- a/backend/file_processing/services/word_validation_service.py
+++ b/backend/file_processing/services/word_validation_service.py
@@ -1,4 +1,5 @@
 import zipfile
+import math
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
@@ -6,6 +7,7 @@ from typing import Any, Optional, Tuple
 EXT_DOCX = ".docx"
 EXT_DOC = ".doc"
 MAX_WORD_PAGES = 100
+DOCX_CHARS_PER_PAGE_ESTIMATE = 2500
 WORD_CORRUPT_ERROR = "Word file is corrupt or has an invalid structure."
 WORD_PROTECTED_ERROR = "Word file is password-protected."
 OLE_SIGNATURE = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
@@ -164,16 +166,83 @@ def check_docx_structure(uploaded_file: Any) -> Tuple[bool, Any]:
 
 
 def extract_docx_page_count(archive: zipfile.ZipFile) -> int:
+    app_pages = 0
     try:
         app_xml = archive.read("docProps/app.xml")
         root = ET.fromstring(app_xml)
         for element in root.iter():
             if element.tag.endswith("Pages") and element.text:
-                return max(int(element.text), 0)
+                app_pages = max(int(element.text), 0)
+                if app_pages > 0:
+                    break
+    except Exception:
+        pass
+
+    try:
+        document_xml = archive.read("word/document.xml")
+    except Exception:
+        return app_pages
+
+    estimated_pages = _estimate_docx_pages_from_document_xml(document_xml)
+    return max(app_pages, estimated_pages)
+
+
+def _estimate_docx_pages_from_document_xml(document_xml: bytes) -> int:
+    try:
+        root = ET.fromstring(document_xml)
     except Exception:
         return 0
 
-    return 0
+    if _local_name(root.tag) != "document":
+        return 0
+
+    manual_page_breaks = 0
+    rendered_page_breaks = 0
+    page_break_before_count = 0
+    section_count = 0
+    text_char_count = 0
+
+    for node in root.iter():
+        node_name = _local_name(node.tag)
+
+        if node_name == "lastRenderedPageBreak":
+            rendered_page_breaks += 1
+        elif node_name == "br":
+            break_type = ""
+            for key, value in node.attrib.items():
+                if key.endswith("type"):
+                    break_type = (value or "").strip().lower()
+                    break
+            if break_type == "page":
+                manual_page_breaks += 1
+        elif node_name == "pageBreakBefore":
+            page_break_before_count += 1
+        elif node_name == "sectPr":
+            section_count += 1
+        elif node_name == "t" and node.text:
+            text_char_count += len(node.text.strip())
+
+    marker_estimate = 0
+    if rendered_page_breaks > 0:
+        marker_estimate = max(marker_estimate, rendered_page_breaks + 1)
+    if manual_page_breaks > 0:
+        marker_estimate = max(marker_estimate, manual_page_breaks + 1)
+    if page_break_before_count > 0:
+        marker_estimate = max(marker_estimate, page_break_before_count + 1)
+    if section_count > 1:
+        marker_estimate = max(marker_estimate, section_count)
+
+    text_estimate = 0
+    if text_char_count > 0:
+        text_estimate = max(1, math.ceil(text_char_count / DOCX_CHARS_PER_PAGE_ESTIMATE))
+
+    return max(marker_estimate, text_estimate)
+
+
+def _local_name(tag_name: str) -> str:
+    if "}" in tag_name:
+        return tag_name.rsplit("}", 1)[1]
+    return tag_name
 
 
 def check_doc_encrypted(uploaded_file: Any) -> Tuple[bool, Optional[str]]:

--- a/backend/file_processing/services/word_validation_service.py
+++ b/backend/file_processing/services/word_validation_service.py
@@ -1,13 +1,18 @@
 import zipfile
 import math
 import xml.etree.ElementTree as ET
+from io import BytesIO
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
+
+from docx import Document
 
 EXT_DOCX = ".docx"
 EXT_DOC = ".doc"
 MAX_WORD_PAGES = 100
 DOCX_CHARS_PER_PAGE_ESTIMATE = 2500
+DOCX_WORDS_PER_PAGE_ESTIMATE = 350
+DOCX_BLOCKS_PER_PAGE_ESTIMATE = 35
 WORD_CORRUPT_ERROR = "Word file is corrupt or has an invalid structure."
 WORD_PROTECTED_ERROR = "Word file is password-protected."
 OLE_SIGNATURE = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
@@ -51,7 +56,8 @@ class DocxStructureValidationHandler(WordValidationHandler):
     def handle(self, context: WordValidationContext) -> Tuple[bool, Optional[str]]:
         try:
             context.uploaded_file.seek(0)
-            with zipfile.ZipFile(context.uploaded_file) as archive:
+            docx_bytes = context.uploaded_file.read()
+            with zipfile.ZipFile(BytesIO(docx_bytes)) as archive:
                 names = set(archive.namelist())
                 if (
                     "[Content_Types].xml" not in names
@@ -59,7 +65,7 @@ class DocxStructureValidationHandler(WordValidationHandler):
                 ):
                     return False, WORD_CORRUPT_ERROR
 
-                context.page_count = extract_docx_page_count(archive)
+                context.page_count = extract_docx_page_count(archive, docx_bytes)
         except Exception:
             return False, WORD_CORRUPT_ERROR
         finally:
@@ -152,12 +158,13 @@ def check_docx_encrypted(uploaded_file: Any) -> Tuple[bool, Optional[str]]:
 def check_docx_structure(uploaded_file: Any) -> Tuple[bool, Any]:
     try:
         uploaded_file.seek(0)
-        with zipfile.ZipFile(uploaded_file) as archive:
+        docx_bytes = uploaded_file.read()
+        with zipfile.ZipFile(BytesIO(docx_bytes)) as archive:
             names = set(archive.namelist())
             if "[Content_Types].xml" not in names or "word/document.xml" not in names:
                 return False, WORD_CORRUPT_ERROR
 
-            page_count = extract_docx_page_count(archive)
+            page_count = extract_docx_page_count(archive, docx_bytes)
             return True, page_count
     except Exception:
         return False, WORD_CORRUPT_ERROR
@@ -165,7 +172,7 @@ def check_docx_structure(uploaded_file: Any) -> Tuple[bool, Any]:
         uploaded_file.seek(0)
 
 
-def extract_docx_page_count(archive: zipfile.ZipFile) -> int:
+def extract_docx_page_count(archive: zipfile.ZipFile, docx_bytes: Optional[bytes] = None) -> int:
     app_pages = 0
     try:
         app_xml = archive.read("docProps/app.xml")
@@ -184,7 +191,72 @@ def extract_docx_page_count(archive: zipfile.ZipFile) -> int:
         return app_pages
 
     estimated_pages = _estimate_docx_pages_from_document_xml(document_xml)
-    return max(app_pages, estimated_pages)
+    python_docx_pages = _estimate_docx_pages_with_python_docx(docx_bytes)
+    return max(app_pages, estimated_pages, python_docx_pages)
+
+
+def _estimate_docx_pages_with_python_docx(docx_bytes: Optional[bytes]) -> int:
+    if not docx_bytes:
+        return 0
+
+    try:
+        document = Document(BytesIO(docx_bytes))
+    except Exception:
+        return 0
+
+    paragraph_count = 0
+    table_row_count = 0
+    word_count = 0
+    explicit_page_breaks = 0
+
+    for paragraph in document.paragraphs:
+        paragraph_count += 1
+        paragraph_text = paragraph.text.strip()
+        if paragraph_text:
+            word_count += len(paragraph_text.split())
+
+        for node in paragraph._p.iter():
+            node_name = _local_name(node.tag)
+            if node_name == "lastRenderedPageBreak":
+                explicit_page_breaks += 1
+            elif node_name == "br":
+                break_type = ""
+                for key, value in node.attrib.items():
+                    if key.endswith("type"):
+                        break_type = (value or "").strip().lower()
+                        break
+                if break_type == "page":
+                    explicit_page_breaks += 1
+
+    for table in document.tables:
+        for row in table.rows:
+            table_row_count += 1
+            for cell in row.cells:
+                cell_text = cell.text.strip()
+                if cell_text:
+                    word_count += len(cell_text.split())
+
+    break_estimate = explicit_page_breaks + 1 if explicit_page_breaks > 0 else 0
+
+    section_estimate = 0
+    try:
+        if len(document.sections) > 1:
+            section_estimate = len(document.sections)
+    except Exception:
+        section_estimate = 0
+
+    word_estimate = 0
+    if word_count > 0:
+        word_estimate = max(1, math.ceil(word_count / DOCX_WORDS_PER_PAGE_ESTIMATE))
+
+    structure_estimate = 0
+    block_count = paragraph_count + table_row_count
+    if block_count > 0:
+        structure_estimate = max(
+            1, math.ceil(block_count / DOCX_BLOCKS_PER_PAGE_ESTIMATE)
+        )
+
+    return max(break_estimate, section_estimate, word_estimate, structure_estimate)
 
 
 def _estimate_docx_pages_from_document_xml(document_xml: bytes) -> int:

--- a/backend/file_processing/services/word_validation_service.py
+++ b/backend/file_processing/services/word_validation_service.py
@@ -23,6 +23,7 @@ DOCX_IMAGE_SMALL_AREA_INCH2 = 1.5
 WORD_CORRUPT_ERROR = "Word file is corrupt or has an invalid structure."
 WORD_PROTECTED_ERROR = "Word file is password-protected."
 OLE_SIGNATURE = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+WORD_DOCUMENT_XML = "word/document.xml"
 
 
 @dataclass
@@ -66,10 +67,7 @@ class DocxStructureValidationHandler(WordValidationHandler):
             docx_bytes = context.uploaded_file.read()
             with zipfile.ZipFile(BytesIO(docx_bytes)) as archive:
                 names = set(archive.namelist())
-                if (
-                    "[Content_Types].xml" not in names
-                    or "word/document.xml" not in names
-                ):
+                if "[Content_Types].xml" not in names or WORD_DOCUMENT_XML not in names:
                     return False, WORD_CORRUPT_ERROR
 
                 context.page_count = extract_docx_page_count(archive, docx_bytes)
@@ -168,7 +166,7 @@ def check_docx_structure(uploaded_file: Any) -> Tuple[bool, Any]:
         docx_bytes = uploaded_file.read()
         with zipfile.ZipFile(BytesIO(docx_bytes)) as archive:
             names = set(archive.namelist())
-            if "[Content_Types].xml" not in names or "word/document.xml" not in names:
+            if "[Content_Types].xml" not in names or WORD_DOCUMENT_XML not in names:
                 return False, WORD_CORRUPT_ERROR
 
             page_count = extract_docx_page_count(archive, docx_bytes)
@@ -195,7 +193,7 @@ def extract_docx_page_count(
         pass
 
     try:
-        document_xml = archive.read("word/document.xml")
+        document_xml = archive.read(WORD_DOCUMENT_XML)
     except Exception:
         return app_pages
 
@@ -208,82 +206,22 @@ def _estimate_docx_pages_with_python_docx(docx_bytes: Optional[bytes]) -> int:
     if not docx_bytes:
         return 0
 
-    try:
-        document = Document(BytesIO(docx_bytes))
-    except Exception:
+    document = _load_docx_document(docx_bytes)
+    if document is None:
         return 0
 
-    paragraph_count = 0
-    table_row_count = 0
-    word_count = 0
-    explicit_page_breaks = 0
-    image_count = 0
-    total_image_area = 0.0
-
     usable_page_area = _estimate_docx_usable_page_area(document)
+    paragraph_count, paragraph_word_count, explicit_page_breaks = (
+        _collect_paragraph_metrics(document)
+    )
+    image_count, total_image_area = _collect_body_image_metrics(document)
+    table_row_count, table_word_count = _collect_table_metrics(document)
 
-    for paragraph in document.paragraphs:
-        paragraph_count += 1
-        paragraph_text = paragraph.text.strip()
-        if paragraph_text:
-            word_count += len(paragraph_text.split())
-
-        for node in paragraph._p.iter():
-            node_name = _local_name(node.tag)
-            if node_name == "lastRenderedPageBreak":
-                explicit_page_breaks += 1
-            elif node_name == "br":
-                break_type = ""
-                for key, value in node.attrib.items():
-                    if key.endswith("type"):
-                        break_type = (value or "").strip().lower()
-                        break
-                if break_type == "page":
-                    explicit_page_breaks += 1
-
-    try:
-        body_node = document.element.body
-    except Exception:
-        body_node = None
-
-    if body_node is not None:
-        for node in body_node.iter():
-            node_name = _local_name(node.tag)
-            if node_name in {"drawing", "pict", "object"}:
-                image_count += 1
-            elif node_name == "extent":
-                cx, cy = _extract_extent_inches(node)
-                if cx > 0 and cy > 0:
-                    total_image_area += cx * cy
-
-    for table in document.tables:
-        for row in table.rows:
-            table_row_count += 1
-            for cell in row.cells:
-                cell_text = cell.text.strip()
-                if cell_text:
-                    word_count += len(cell_text.split())
-
-    break_estimate = explicit_page_breaks + 1 if explicit_page_breaks > 0 else 0
-
-    section_estimate = 0
-    try:
-        if len(document.sections) > 1:
-            section_estimate = len(document.sections)
-    except Exception:
-        section_estimate = 0
-
-    word_estimate = 0
-    if word_count > 0:
-        word_estimate = max(1, math.ceil(word_count / DOCX_WORDS_PER_PAGE_ESTIMATE))
-
-    structure_estimate = 0
-    block_count = paragraph_count + table_row_count
-    if block_count > 0:
-        structure_estimate = max(
-            1, math.ceil(block_count / DOCX_BLOCKS_PER_PAGE_ESTIMATE)
-        )
-
+    word_count = paragraph_word_count + table_word_count
+    section_estimate = _estimate_section_pages(document)
+    word_estimate = _estimate_pages_from_words(word_count)
+    structure_estimate = _estimate_pages_from_blocks(paragraph_count + table_row_count)
+    break_estimate = _estimate_pages_from_explicit_breaks(explicit_page_breaks)
     image_estimate = _estimate_pages_from_images(
         image_count=image_count,
         total_image_area=total_image_area,
@@ -297,6 +235,123 @@ def _estimate_docx_pages_with_python_docx(docx_bytes: Optional[bytes]) -> int:
         structure_estimate,
         image_estimate,
     )
+
+
+def _load_docx_document(docx_bytes: bytes) -> Optional[Document]:
+    try:
+        return Document(BytesIO(docx_bytes))
+    except Exception:
+        return None
+
+
+def _collect_paragraph_metrics(document: Document) -> Tuple[int, int, int]:
+    paragraph_count = 0
+    word_count = 0
+    explicit_page_breaks = 0
+
+    for paragraph in document.paragraphs:
+        paragraph_count += 1
+        word_count += _count_words(paragraph.text)
+        explicit_page_breaks += _count_explicit_breaks_in_paragraph(paragraph)
+
+    return paragraph_count, word_count, explicit_page_breaks
+
+
+def _count_words(text: str) -> int:
+    cleaned_text = (text or "").strip()
+    if not cleaned_text:
+        return 0
+    return len(cleaned_text.split())
+
+
+def _count_explicit_breaks_in_paragraph(paragraph: Any) -> int:
+    breaks = 0
+    for node in paragraph._p.iter():
+        node_name = _local_name(node.tag)
+        if node_name == "lastRenderedPageBreak":
+            breaks += 1
+            continue
+        if node_name == "br" and _is_page_break_node(node):
+            breaks += 1
+    return breaks
+
+
+def _is_page_break_node(node: Any) -> bool:
+    break_type = ""
+    for key, value in node.attrib.items():
+        if key.endswith("type"):
+            break_type = (value or "").strip().lower()
+            break
+    return break_type == "page"
+
+
+def _collect_body_image_metrics(document: Document) -> Tuple[int, float]:
+    body_node = _safe_document_body(document)
+    if body_node is None:
+        return 0, 0.0
+
+    image_count = 0
+    total_image_area = 0.0
+    for node in body_node.iter():
+        node_name = _local_name(node.tag)
+        if node_name in {"drawing", "pict", "object"}:
+            image_count += 1
+            continue
+        if node_name == "extent":
+            cx, cy = _extract_extent_inches(node)
+            if cx > 0 and cy > 0:
+                total_image_area += cx * cy
+
+    return image_count, total_image_area
+
+
+def _safe_document_body(document: Document) -> Any:
+    try:
+        return document.element.body
+    except Exception:
+        return None
+
+
+def _collect_table_metrics(document: Document) -> Tuple[int, int]:
+    table_row_count = 0
+    word_count = 0
+
+    for table in document.tables:
+        for row in table.rows:
+            table_row_count += 1
+            for cell in row.cells:
+                word_count += _count_words(cell.text)
+
+    return table_row_count, word_count
+
+
+def _estimate_pages_from_explicit_breaks(explicit_page_breaks: int) -> int:
+    if explicit_page_breaks <= 0:
+        return 0
+    return explicit_page_breaks + 1
+
+
+def _estimate_section_pages(document: Document) -> int:
+    try:
+        section_count = len(document.sections)
+    except Exception:
+        return 0
+
+    if section_count > 1:
+        return section_count
+    return 0
+
+
+def _estimate_pages_from_words(word_count: int) -> int:
+    if word_count <= 0:
+        return 0
+    return max(1, math.ceil(word_count / DOCX_WORDS_PER_PAGE_ESTIMATE))
+
+
+def _estimate_pages_from_blocks(block_count: int) -> int:
+    if block_count <= 0:
+        return 0
+    return max(1, math.ceil(block_count / DOCX_BLOCKS_PER_PAGE_ESTIMATE))
 
 
 def _estimate_docx_usable_page_area(document: Document) -> float:
@@ -411,41 +466,66 @@ def _emu_to_inches(value: Any, default: float) -> float:
 
 
 def _estimate_docx_pages_from_document_xml(document_xml: bytes) -> int:
+    root = _parse_docx_document_root(document_xml)
+    if root is None:
+        return 0
+
+    marker_counts, text_char_count = _collect_docx_xml_marker_counts(root)
+    marker_estimate = _estimate_pages_from_docx_xml_markers(marker_counts)
+    text_estimate = _estimate_pages_from_text_char_count(text_char_count)
+    return max(marker_estimate, text_estimate)
+
+
+def _parse_docx_document_root(document_xml: bytes) -> Optional[ET.Element]:
     try:
         root = ET.fromstring(document_xml)
     except Exception:
-        return 0
+        return None
 
     if _local_name(root.tag) != "document":
-        return 0
+        return None
+    return root
 
-    manual_page_breaks = 0
-    rendered_page_breaks = 0
-    page_break_before_count = 0
-    section_count = 0
+
+def _collect_docx_xml_marker_counts(root: ET.Element) -> Tuple[dict, int]:
+    marker_counts = {
+        "manual_page_breaks": 0,
+        "rendered_page_breaks": 0,
+        "page_break_before_count": 0,
+        "section_count": 0,
+    }
     text_char_count = 0
 
     for node in root.iter():
         node_name = _local_name(node.tag)
-
         if node_name == "lastRenderedPageBreak":
-            rendered_page_breaks += 1
+            marker_counts["rendered_page_breaks"] += 1
         elif node_name == "br":
-            break_type = ""
-            for key, value in node.attrib.items():
-                if key.endswith("type"):
-                    break_type = (value or "").strip().lower()
-                    break
-            if break_type == "page":
-                manual_page_breaks += 1
+            if _is_page_break_node(node):
+                marker_counts["manual_page_breaks"] += 1
         elif node_name == "pageBreakBefore":
-            page_break_before_count += 1
+            marker_counts["page_break_before_count"] += 1
         elif node_name == "sectPr":
-            section_count += 1
-        elif node_name == "t" and node.text:
-            text_char_count += len(node.text.strip())
+            marker_counts["section_count"] += 1
+        elif node_name == "t":
+            text_char_count += _count_text_characters(node.text)
 
+    return marker_counts, text_char_count
+
+
+def _count_text_characters(text: Optional[str]) -> int:
+    if not text:
+        return 0
+    return len(text.strip())
+
+
+def _estimate_pages_from_docx_xml_markers(marker_counts: dict) -> int:
     marker_estimate = 0
+    rendered_page_breaks = marker_counts["rendered_page_breaks"]
+    manual_page_breaks = marker_counts["manual_page_breaks"]
+    page_break_before_count = marker_counts["page_break_before_count"]
+    section_count = marker_counts["section_count"]
+
     if rendered_page_breaks > 0:
         marker_estimate = max(marker_estimate, rendered_page_breaks + 1)
     if manual_page_breaks > 0:
@@ -454,14 +534,13 @@ def _estimate_docx_pages_from_document_xml(document_xml: bytes) -> int:
         marker_estimate = max(marker_estimate, page_break_before_count + 1)
     if section_count > 1:
         marker_estimate = max(marker_estimate, section_count)
+    return marker_estimate
 
-    text_estimate = 0
-    if text_char_count > 0:
-        text_estimate = max(
-            1, math.ceil(text_char_count / DOCX_CHARS_PER_PAGE_ESTIMATE)
-        )
 
-    return max(marker_estimate, text_estimate)
+def _estimate_pages_from_text_char_count(text_char_count: int) -> int:
+    if text_char_count <= 0:
+        return 0
+    return max(1, math.ceil(text_char_count / DOCX_CHARS_PER_PAGE_ESTIMATE))
 
 
 def _local_name(tag_name: str) -> str:

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2298,6 +2298,18 @@ class TestWordValidationService(unittest.TestCase):
             word_validation_service.extract_docx_page_count(ArchiveAppPagesOnly()), 7
         )
 
+    def test_extract_docx_page_count_breaks_after_first_positive_pages(self):
+        class ArchiveAppPagesBreak:
+            def read(self, name):
+                if name == "docProps/app.xml":
+                    # If break is not hit, second Pages=0 can overwrite app_pages.
+                    return b"<Properties><Pages>9</Pages><Pages>0</Pages></Properties>"
+                raise KeyError(name)
+
+        self.assertEqual(
+            word_validation_service.extract_docx_page_count(ArchiveAppPagesBreak()), 9
+        )
+
     def test_extract_docx_page_count_uses_document_fallback_when_app_xml_missing(self):
         class ArchiveNoAppPages:
             def read(self, name):
@@ -2584,6 +2596,23 @@ class TestWordValidationService(unittest.TestCase):
         cx, cy = word_validation_service._extract_extent_inches(_Node())
         self.assertEqual(cx, 0.0)
         self.assertGreater(cy, 0.0)
+
+    def test_extract_extent_inches_handles_cy_success_and_failure_paths(self):
+        class _NodeCySuccess:
+            attrib = {"other": "x", "cy": "1828800"}
+
+        class _NodeCyFailure:
+            attrib = {"other": "x", "cy": "not-a-number"}
+
+        cx_ok, cy_ok = word_validation_service._extract_extent_inches(_NodeCySuccess())
+        cx_bad, cy_bad = word_validation_service._extract_extent_inches(
+            _NodeCyFailure()
+        )
+
+        self.assertEqual(cx_ok, 0.0)
+        self.assertGreater(cy_ok, 0.0)
+        self.assertEqual(cx_bad, 0.0)
+        self.assertEqual(cy_bad, 0.0)
 
     def test_extract_extent_inches_reads_both_cx_and_cy_attributes(self):
         class _Node:

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2310,6 +2310,17 @@ class TestWordValidationService(unittest.TestCase):
             word_validation_service.extract_docx_page_count(ArchiveAppPagesBreak()), 9
         )
 
+    def test_extract_docx_page_count_keeps_zero_when_pages_is_zero(self):
+        class ArchiveZeroPages:
+            def read(self, name):
+                if name == "docProps/app.xml":
+                    return b"<Properties><Pages>0</Pages></Properties>"
+                raise KeyError(name)
+
+        self.assertEqual(
+            word_validation_service.extract_docx_page_count(ArchiveZeroPages()), 0
+        )
+
     def test_extract_docx_page_count_uses_document_fallback_when_app_xml_missing(self):
         class ArchiveNoAppPages:
             def read(self, name):

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2259,3 +2259,47 @@ class TestWordValidationService(unittest.TestCase):
         self.assertEqual(
             word_validation_service.extract_docx_page_count(ArchiveNoPages()), 0
         )
+
+    def test_extract_docx_page_count_uses_document_fallback_when_app_xml_missing(self):
+        class ArchiveNoAppPages:
+            def read(self, name):
+                if name == "docProps/app.xml":
+                    return b"<Properties><Template>Normal</Template></Properties>"
+                if name == "word/document.xml":
+                    namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                    page_breaks = "".join(
+                        "<w:lastRenderedPageBreak/>"
+                        for _ in range(word_validation_service.MAX_WORD_PAGES)
+                    )
+                    return (
+                        f'<w:document xmlns:w="{namespace}"><w:body><w:p><w:r>'
+                        f"{page_breaks}</w:r></w:p></w:body></w:document>"
+                    ).encode("utf-8")
+                raise KeyError(name)
+
+        page_count = word_validation_service.extract_docx_page_count(
+            ArchiveNoAppPages()
+        )
+        self.assertGreater(page_count, word_validation_service.MAX_WORD_PAGES)
+
+    def test_extract_docx_page_count_prefers_higher_document_estimate(self):
+        class ArchiveStaleAppPages:
+            def read(self, name):
+                if name == "docProps/app.xml":
+                    return b"<Properties><Pages>2</Pages></Properties>"
+                if name == "word/document.xml":
+                    namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                    page_break_before_nodes = "".join(
+                        "<w:p><w:pPr><w:pageBreakBefore/></w:pPr></w:p>"
+                        for _ in range(word_validation_service.MAX_WORD_PAGES)
+                    )
+                    return (
+                        f'<w:document xmlns:w="{namespace}"><w:body>'
+                        f"{page_break_before_nodes}</w:body></w:document>"
+                    ).encode("utf-8")
+                raise KeyError(name)
+
+        page_count = word_validation_service.extract_docx_page_count(
+            ArchiveStaleAppPages()
+        )
+        self.assertGreater(page_count, word_validation_service.MAX_WORD_PAGES)

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2303,3 +2303,29 @@ class TestWordValidationService(unittest.TestCase):
             ArchiveStaleAppPages()
         )
         self.assertGreater(page_count, word_validation_service.MAX_WORD_PAGES)
+
+    @patch(
+        "file_processing.services.word_validation_service._estimate_docx_pages_with_python_docx",
+        return_value=word_validation_service.MAX_WORD_PAGES + 10,
+    )
+    def test_validate_word_docx_rejects_over_limit_from_python_docx_fallback(
+        self, _mock_python_docx_estimate
+    ):
+        content = BytesIO()
+        with zipfile.ZipFile(content, "w") as archive:
+            archive.writestr("[Content_Types].xml", "<Types></Types>")
+            archive.writestr("word/document.xml", "<w:document></w:document>")
+
+        f = SimpleUploadedFile(
+            "large.docx",
+            content.getvalue(),
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+        is_valid, error = word_validation_service.validate_word(f, ".docx")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(
+            error,
+            f"Word exceeds the maximum allowed page count of {word_validation_service.MAX_WORD_PAGES}.",
+        )

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2553,6 +2553,10 @@ class TestWordValidationService(unittest.TestCase):
         self.assertEqual(word_validation_service._emu_to_inches(0, 3.2), 3.2)
         self.assertEqual(word_validation_service._emu_to_inches(-10, 4.1), 4.1)
 
+    def test_count_text_characters_returns_zero_for_empty_text(self):
+        self.assertEqual(word_validation_service._count_text_characters(None), 0)
+        self.assertEqual(word_validation_service._count_text_characters(""), 0)
+
     def test_is_page_break_node_detects_type_attribute(self):
         class _Node:
             attrib = {"{w}type": "page"}

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2563,6 +2563,16 @@ class TestWordValidationService(unittest.TestCase):
 
         self.assertTrue(word_validation_service._is_page_break_node(_Node()))
 
+    def test_is_page_break_node_ignores_non_page_type_and_missing_type(self):
+        class _NonPageNode:
+            attrib = {"{w}type": "textWrapping"}
+
+        class _NoTypeNode:
+            attrib = {"other": "value"}
+
+        self.assertFalse(word_validation_service._is_page_break_node(_NonPageNode()))
+        self.assertFalse(word_validation_service._is_page_break_node(_NoTypeNode()))
+
     def test_estimate_pages_from_blocks_returns_zero_for_non_positive(self):
         self.assertEqual(word_validation_service._estimate_pages_from_blocks(0), 0)
         self.assertEqual(word_validation_service._estimate_pages_from_blocks(-3), 0)
@@ -2574,6 +2584,39 @@ class TestWordValidationService(unittest.TestCase):
         cx, cy = word_validation_service._extract_extent_inches(_Node())
         self.assertEqual(cx, 0.0)
         self.assertGreater(cy, 0.0)
+
+    def test_extract_extent_inches_reads_both_cx_and_cy_attributes(self):
+        class _Node:
+            attrib = {"cx": "914400", "cy": "1828800"}
+
+        cx, cy = word_validation_service._extract_extent_inches(_Node())
+        self.assertGreater(cx, 0.0)
+        self.assertGreater(cy, 0.0)
+
+    def test_collect_body_image_metrics_does_not_add_area_when_extent_incomplete(self):
+        class _Node:
+            def __init__(self, tag, attrib=None):
+                self.tag = tag
+                self.attrib = attrib or {}
+
+        class _Body:
+            def iter(self):
+                return [
+                    _Node("{w}drawing"),
+                    _Node("{wp}extent", {"cx": "914400"}),
+                ]
+
+        class _Element:
+            body = _Body()
+
+        class _Document:
+            element = _Element()
+
+        image_count, total_area = word_validation_service._collect_body_image_metrics(
+            _Document()
+        )
+        self.assertEqual(image_count, 1)
+        self.assertEqual(total_area, 0.0)
 
     def test_estimate_docx_pages_from_document_xml_counts_text_sections_and_page_break(
         self,
@@ -2595,6 +2638,25 @@ class TestWordValidationService(unittest.TestCase):
         )
 
         self.assertEqual(estimate, 2)
+
+    def test_collect_docx_xml_marker_counts_br_non_page_not_counted(self):
+        namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        document_xml = (
+            f'<w:document xmlns:w="{namespace}">'
+            "<w:body>"
+            "<w:p><w:r><w:br w:type='textWrapping'/></w:r></w:p>"
+            "<w:p><w:r><w:br w:type='page'/></w:r></w:p>"
+            "</w:body>"
+            "</w:document>"
+        ).encode("utf-8")
+
+        root = word_validation_service._parse_docx_document_root(document_xml)
+        marker_counts, text_char_count = (
+            word_validation_service._collect_docx_xml_marker_counts(root)
+        )
+
+        self.assertEqual(marker_counts["manual_page_breaks"], 1)
+        self.assertEqual(text_char_count, 0)
 
     @patch(
         "file_processing.services.word_validation_service._estimate_docx_pages_with_python_docx",

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -3,12 +3,15 @@ import tempfile
 import builtins
 import zipfile
 import unittest
+import base64
 
 from django.test import TestCase
 from django.core.files.uploadedfile import SimpleUploadedFile
 from unittest.mock import patch, MagicMock, PropertyMock
 from PyPDF2.errors import PdfReadError
 from openpyxl import Workbook
+from docx import Document
+from docx.shared import Inches
 
 from file_processing.services.ocr_service import OCRService
 from io import BytesIO
@@ -124,7 +127,6 @@ class TestOCRService(TestCase):
         text = OCRService._ocr_single_image("mock_image")
 
         self.assertEqual(text, "OCR text")
-
 
     @patch("file_processing.services.ocr_service.OCRService._ocr_single_image")
     def test_process_image_success(self, mock_ocr_single):
@@ -2179,6 +2181,11 @@ class TestWordValidationServiceCoverage(TestCase):
 
 
 class TestWordValidationService(unittest.TestCase):
+    _ONE_PIXEL_PNG_BASE64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/"
+        "x8AAwMCAO2vN6kAAAAASUVORK5CYII="
+    )
+
     def _build_valid_docx(self, pages=1):
         content = BytesIO()
         with zipfile.ZipFile(content, "w") as archive:
@@ -2189,6 +2196,26 @@ class TestWordValidationService(unittest.TestCase):
                 f"<Properties><Pages>{pages}</Pages></Properties>",
             )
         return content.getvalue()
+
+    def _build_image_heavy_docx(self, image_count=101):
+        image_bytes = base64.b64decode(self._ONE_PIXEL_PNG_BASE64)
+        doc = Document()
+
+        for _ in range(image_count):
+            doc.add_picture(BytesIO(image_bytes), width=Inches(6.3), height=Inches(8.8))
+
+        out = BytesIO()
+        doc.save(out)
+        return out.getvalue()
+
+    def _build_blank_pages_docx(self, page_count=101):
+        doc = Document()
+        for _ in range(max(0, page_count - 1)):
+            doc.add_page_break()
+
+        out = BytesIO()
+        doc.save(out)
+        return out.getvalue()
 
     def test_validate_word_docx_happy_path(self):
         f = SimpleUploadedFile(
@@ -2266,7 +2293,9 @@ class TestWordValidationService(unittest.TestCase):
                 if name == "docProps/app.xml":
                     return b"<Properties><Template>Normal</Template></Properties>"
                 if name == "word/document.xml":
-                    namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                    namespace = (
+                        "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                    )
                     page_breaks = "".join(
                         "<w:lastRenderedPageBreak/>"
                         for _ in range(word_validation_service.MAX_WORD_PAGES)
@@ -2288,7 +2317,9 @@ class TestWordValidationService(unittest.TestCase):
                 if name == "docProps/app.xml":
                     return b"<Properties><Pages>2</Pages></Properties>"
                 if name == "word/document.xml":
-                    namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                    namespace = (
+                        "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                    )
                     page_break_before_nodes = "".join(
                         "<w:p><w:pPr><w:pageBreakBefore/></w:pPr></w:p>"
                         for _ in range(word_validation_service.MAX_WORD_PAGES)
@@ -2303,6 +2334,63 @@ class TestWordValidationService(unittest.TestCase):
             ArchiveStaleAppPages()
         )
         self.assertGreater(page_count, word_validation_service.MAX_WORD_PAGES)
+
+    def test_validate_word_docx_rejects_image_heavy_document_without_text(self):
+        f = SimpleUploadedFile(
+            "image-heavy.docx",
+            self._build_image_heavy_docx(image_count=101),
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+        is_valid, error = word_validation_service.validate_word(f, ".docx")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(
+            error,
+            f"Word exceeds the maximum allowed page count of {word_validation_service.MAX_WORD_PAGES}.",
+        )
+
+    def test_validate_word_docx_rejects_blank_pages_document(self):
+        f = SimpleUploadedFile(
+            "blank-pages.docx",
+            self._build_blank_pages_docx(page_count=101),
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+        is_valid, error = word_validation_service.validate_word(f, ".docx")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(
+            error,
+            f"Word exceeds the maximum allowed page count of {word_validation_service.MAX_WORD_PAGES}.",
+        )
+
+    def test_estimate_pages_from_images_medium_images_not_undercounted(self):
+        estimate = word_validation_service._estimate_pages_from_images(
+            image_count=221,
+            total_image_area=1990.4,
+            usable_page_area=58.5,
+        )
+        self.assertGreater(estimate, word_validation_service.MAX_WORD_PAGES)
+
+    def test_estimate_docx_usable_page_area_handles_invalid_section_values(self):
+        class _BadSection:
+            page_width = "7772400"
+            page_height = "10058400"
+
+            @property
+            def left_margin(self):
+                raise ValueError("invalid twips")
+
+            right_margin = "1440.0000000000002"
+            top_margin = "1440"
+            bottom_margin = "1440"
+
+        class _BadDocument:
+            sections = [_BadSection()]
+
+        area = word_validation_service._estimate_docx_usable_page_area(_BadDocument())
+        self.assertGreater(area, 0)
 
     @patch(
         "file_processing.services.word_validation_service._estimate_docx_pages_with_python_docx",

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2392,6 +2392,177 @@ class TestWordValidationService(unittest.TestCase):
         area = word_validation_service._estimate_docx_usable_page_area(_BadDocument())
         self.assertGreater(area, 0)
 
+    def test_estimate_docx_usable_page_area_falls_back_to_defaults_when_sections_fail(
+        self,
+    ):
+        class _BadDocument:
+            @property
+            def sections(self):
+                raise RuntimeError("no sections")
+
+        area = word_validation_service._estimate_docx_usable_page_area(_BadDocument())
+        expected = (
+            word_validation_service.DOCX_DEFAULT_PAGE_WIDTH_INCH
+            - 2 * word_validation_service.DOCX_DEFAULT_MARGIN_INCH
+        ) * (
+            word_validation_service.DOCX_DEFAULT_PAGE_HEIGHT_INCH
+            - 2 * word_validation_service.DOCX_DEFAULT_MARGIN_INCH
+        )
+        self.assertAlmostEqual(area, expected)
+
+    def test_estimate_docx_pages_with_python_docx_handles_body_access_exception(self):
+        class _Node:
+            def __init__(self, tag, attrib=None):
+                self.tag = tag
+                self.attrib = attrib or {}
+
+        class _ParagraphXml:
+            def iter(self):
+                return [
+                    _Node("{w}br", {"{w}type": "page"}),
+                    _Node("{w}lastRenderedPageBreak"),
+                ]
+
+        class _Paragraph:
+            text = "hello world"
+            _p = _ParagraphXml()
+
+        class _Cell:
+            text = "table words"
+
+        class _Row:
+            cells = [_Cell()]
+
+        class _Table:
+            rows = [_Row()]
+
+        class _Document:
+            paragraphs = [_Paragraph()]
+            tables = [_Table()]
+
+            @property
+            def sections(self):
+                raise ValueError("section decode error")
+
+            @property
+            def element(self):
+                raise ValueError("no body")
+
+        with patch(
+            "file_processing.services.word_validation_service.Document",
+            return_value=_Document(),
+        ):
+            estimate = word_validation_service._estimate_docx_pages_with_python_docx(
+                b"fake"
+            )
+
+        self.assertGreaterEqual(estimate, 1)
+
+    def test_estimate_docx_pages_with_python_docx_counts_body_drawings_and_sections(
+        self,
+    ):
+        class _Node:
+            def __init__(self, tag, attrib=None):
+                self.tag = tag
+                self.attrib = attrib or {}
+
+        class _Body:
+            def iter(self):
+                return [
+                    _Node("{w}drawing"),
+                    _Node("{wp}extent", {"cx": "914400", "cy": "1828800"}),
+                ]
+
+        class _Element:
+            body = _Body()
+
+        class _ParagraphXml:
+            def iter(self):
+                return []
+
+        class _Paragraph:
+            text = ""
+            _p = _ParagraphXml()
+
+        class _Section:
+            page_width = 7772400
+            page_height = 10058400
+            left_margin = 914400
+            right_margin = 914400
+            top_margin = 914400
+            bottom_margin = 914400
+
+        class _Document:
+            paragraphs = [_Paragraph()]
+            tables = []
+            sections = [_Section(), _Section()]
+            element = _Element()
+
+        with patch(
+            "file_processing.services.word_validation_service.Document",
+            return_value=_Document(),
+        ):
+            estimate = word_validation_service._estimate_docx_pages_with_python_docx(
+                b"fake"
+            )
+
+        self.assertGreaterEqual(estimate, 2)
+
+    def test_estimate_pages_from_images_small_and_tiny_branches(self):
+        small_estimate = word_validation_service._estimate_pages_from_images(
+            image_count=9,
+            total_image_area=18.0,
+            usable_page_area=60.0,
+        )
+        tiny_estimate = word_validation_service._estimate_pages_from_images(
+            image_count=12,
+            total_image_area=6.0,
+            usable_page_area=60.0,
+        )
+        no_area_estimate = word_validation_service._estimate_pages_from_images(
+            image_count=12,
+            total_image_area=0.0,
+            usable_page_area=60.0,
+        )
+
+        self.assertEqual(small_estimate, 3)
+        self.assertEqual(tiny_estimate, 2)
+        self.assertEqual(no_area_estimate, 2)
+
+    def test_extract_extent_inches_handles_invalid_numeric_values(self):
+        class _Node:
+            attrib = {"cx": "invalid-cx", "cy": "invalid-cy"}
+
+        cx, cy = word_validation_service._extract_extent_inches(_Node())
+        self.assertEqual(cx, 0.0)
+        self.assertEqual(cy, 0.0)
+
+    def test_emu_to_inches_handles_invalid_and_non_positive_values(self):
+        self.assertEqual(word_validation_service._emu_to_inches("abc", 7.5), 7.5)
+        self.assertEqual(word_validation_service._emu_to_inches(0, 3.2), 3.2)
+        self.assertEqual(word_validation_service._emu_to_inches(-10, 4.1), 4.1)
+
+    def test_estimate_docx_pages_from_document_xml_counts_text_sections_and_page_break(
+        self,
+    ):
+        namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        document_xml = (
+            f'<w:document xmlns:w="{namespace}">'
+            "<w:body>"
+            "<w:p><w:r><w:br w:type='page'/></w:r></w:p>"
+            "<w:p><w:r><w:t>abc</w:t></w:r></w:p>"
+            "<w:sectPr></w:sectPr>"
+            "<w:sectPr></w:sectPr>"
+            "</w:body>"
+            "</w:document>"
+        ).encode("utf-8")
+
+        estimate = word_validation_service._estimate_docx_pages_from_document_xml(
+            document_xml
+        )
+
+        self.assertEqual(estimate, 2)
+
     @patch(
         "file_processing.services.word_validation_service._estimate_docx_pages_with_python_docx",
         return_value=word_validation_service.MAX_WORD_PAGES + 10,

--- a/backend/file_processing/tests/test_services.py
+++ b/backend/file_processing/tests/test_services.py
@@ -2287,6 +2287,17 @@ class TestWordValidationService(unittest.TestCase):
             word_validation_service.extract_docx_page_count(ArchiveNoPages()), 0
         )
 
+    def test_extract_docx_page_count_uses_positive_app_pages(self):
+        class ArchiveAppPagesOnly:
+            def read(self, name):
+                if name == "docProps/app.xml":
+                    return b"<Properties><Pages>7</Pages></Properties>"
+                raise KeyError(name)
+
+        self.assertEqual(
+            word_validation_service.extract_docx_page_count(ArchiveAppPagesOnly()), 7
+        )
+
     def test_extract_docx_page_count_uses_document_fallback_when_app_xml_missing(self):
         class ArchiveNoAppPages:
             def read(self, name):
@@ -2541,6 +2552,24 @@ class TestWordValidationService(unittest.TestCase):
         self.assertEqual(word_validation_service._emu_to_inches("abc", 7.5), 7.5)
         self.assertEqual(word_validation_service._emu_to_inches(0, 3.2), 3.2)
         self.assertEqual(word_validation_service._emu_to_inches(-10, 4.1), 4.1)
+
+    def test_is_page_break_node_detects_type_attribute(self):
+        class _Node:
+            attrib = {"{w}type": "page"}
+
+        self.assertTrue(word_validation_service._is_page_break_node(_Node()))
+
+    def test_estimate_pages_from_blocks_returns_zero_for_non_positive(self):
+        self.assertEqual(word_validation_service._estimate_pages_from_blocks(0), 0)
+        self.assertEqual(word_validation_service._estimate_pages_from_blocks(-3), 0)
+
+    def test_extract_extent_inches_reads_cy_attribute(self):
+        class _Node:
+            attrib = {"cy": "1828800"}
+
+        cx, cy = word_validation_service._extract_extent_inches(_Node())
+        self.assertEqual(cx, 0.0)
+        self.assertGreater(cy, 0.0)
 
     def test_estimate_docx_pages_from_document_xml_counts_text_sections_and_page_break(
         self,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,7 @@ opencv-python-headless==4.8.0.76
 numpy==1.26.4
 resend==2.26.0
 olefile==0.47
+python-docx==1.1.2
 
 PyJWT
 google-auth-oauthlib


### PR DESCRIPTION
<!-- Use [**Conventional Commits**](https://www.conventionalcommits.org/en/v1.0.0/) format for PR titles:

```
<type>(<scope>): <description>
```

### **Common Types:**

* `feat`: New feature
* `fix`: Bug fix
* `docs`: Documentation changes
* `style`: Code style changes (formatting, no logic changes)
* `refactor`: Code refactoring
* `test`: Adding or updating tests
* `chore`: Maintenance tasks, dependency updates

### **Description Field:**

* Recommended to start a \<description\> with a verb (add, resolve, update, etc.)

### **Examples:**

* `feat(auth): add OAuth2 login integration`
* `fix(api): resolve null pointer exception in user service`
* `docs(readme): update installation instructions`
* `refactor(database): optimize query performance`
* `feat(BE): add vector DB connection`
* `fix(FE): login redirection` -->

## Summary
This PR refactors DOCX page-limit validation to make the 100-page rule stricter and more reliable, especially for files where metadata is missing, stale, or easy to bypass.

Key changes:
- Improved DOCX page counting in word_validation_service with layered estimation:
  - Uses docProps/app.xml when available.
  - Adds fallback parsing of word/document.xml markers (rendered/manual page breaks, pageBreakBefore, section count, text length).
  - Adds python-docx based structural estimation (paragraphs, words, explicit breaks, sections, tables, image density, and image area).
  - Uses the highest estimate from available strategies to avoid undercounting.
- Added python-docx dependency in backend requirements.
- Expanded tests significantly in file_processing test suite:
  - Covers stale/missing page metadata scenarios.
  - Covers blank-page and image-heavy DOCX cases that should exceed the limit.
  - Covers edge cases for section dimensions, image/page-area heuristics, and parser fallbacks.
- Minor formatting cleanup in settings.py (quote style consistency, no behavior change).

<!--- Briefly explain what this PR does and why-->

## How to Test

<!--- Steps to manually test or verify functionality-->

1. Go to backend folder and install dependencies `pip install -r requirements.txt`
2. Run the focused test module `python manage.py test file_processing.tests.test_services`
3. (Optional) Run full backend test suite, `python manage.py test`
4. Expected result:
  - All related file_processing tests pass.
  - DOCX files that effectively exceed 100 pages (including image-heavy or blank-page docs) are rejected with the max-page error.


## Related Issues

<!--- Link to relevant issues, e.g., Closes #123, Fixes #456, Related to #789 -->

## Author Checklist

- [x] Code follows team coding standards and style guide
- [x] Self-reviewed the code changes
- [x] Added/updated tests for new functionality
- [x] All tests pass locally
- [x] Code is properly documented
- [x] Synced with latest `main` branch
- [x] PR title follows conventional commit format
- [x] Meaningful commit messages used

## Additional Notes

<!-- Any additional context, screenshots, or information reviewers should know -->

## Type of task

<!--- Please checklist options that are relevant -->

- [x] Data Processing (for tasks involving data handling or manipulation)
- [ ] Model Training (for tasks involving model training)
- [ ] API Development (for developing or serving model via API)
- [ ] UI Development (for developing or improving user interface)
- [x] Testing (for writing or updating tests)
- [ ] Debugging (for fixing errors or investigating issues)
- [x] Refactor (for code improvements without changing functionality)
- [ ] Performance Improvement / Optimization (for optimizations related to speed or efficiency)
- [ ] Security (for tasks related to security updates or patches)
- [ ] Documentation (for updating or improving documentation)
- [ ] Monitoring (for adding or updating monitoring capabilities)
- [ ] All

## Reviewer(s)

<!--- Please add the names or GitHub usernames of the reviewers -->

- [ ] @naylafn 