### PR TITLE
Refactor monitoring alerts and improve dashboard UX

### DIFF
--- a/backend/authentication/login/http.py
+++ b/backend/authentication/login/http.py
@@ -21,6 +21,7 @@ from authentication.login.exceptions import (
     LoginServiceError,
 )
 from authentication.serializers import LoginSerializer
+from monitoring.interfaces.http.decorators import track_auth_metric
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,7 @@ class LoginView(APIView):
     def get_login_use_case(self):
         return build_login_use_case()
 
+    @track_auth_metric("auth.login")
     def post(self, request):
         serializer = LoginSerializer(data=request.data)
         if not serializer.is_valid():

--- a/backend/authentication/tests/test_login.py
+++ b/backend/authentication/tests/test_login.py
@@ -38,6 +38,38 @@ class LoginViewTest(APISimpleTestCase):
         self.assertEqual(response.data["user"]["email"], "user@example.com")
         self.assertNotIn("password", response.data["user"])
 
+    @patch("monitoring.interfaces.http.decorators.get_monitoring_service")
+    @patch("authentication.login.http.build_login_use_case")
+    def test_login_records_auth_metric_event(self, mock_builder, mock_get_monitoring_service):
+        from authentication.login.entities import AuthenticatedUser, LoginResult, TokenPair
+
+        monitoring_service = MagicMock()
+        mock_get_monitoring_service.return_value = monitoring_service
+
+        use_case = MagicMock()
+        use_case.execute.return_value = LoginResult(
+            tokens=TokenPair(access_token="access-token", refresh_token="refresh-token"),
+            user=AuthenticatedUser(
+                id=str(uuid.uuid4()),
+                email="user@example.com",
+                name="John Doe",
+            ),
+        )
+        mock_builder.return_value = use_case
+
+        response = self.client.post(
+            self.url,
+            {"email": "user@example.com", "password": "securePass1"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        monitoring_service.record_event.assert_called_once_with(
+            event_name="auth.login",
+            outcome="success",
+            endpoint="/auth/login/",
+        )
+
     # Negative
     def test_login_missing_email_returns_400(self):
         response = self.client.post(

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -120,6 +120,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "monitoring.interfaces.http.middleware.MonitoringRequestMetricsMiddleware",
 ]
 
 raw_cors = os.environ.get("DJANGO_CORS_ALLOWED_ORIGINS", "http://localhost:3000")

--- a/backend/monitoring/MONITORING.md
+++ b/backend/monitoring/MONITORING.md
@@ -1,0 +1,251 @@
+# Monitoring Module Documentation
+
+Last updated: April 26, 2026
+
+## 1. Scope
+
+Monitoring module provides backend health/readiness checks, traffic metrics, auth activity metrics, snapshot API, and SSE stream for live dashboard updates.
+
+This module is split into:
+- `application`: access policy + orchestration services.
+- `domain`: entities/contracts.
+- `infrastructure`: repositories, health checks, Discord notifier.
+- `interfaces/http`: endpoints, permissions/decorators, request metrics middleware.
+
+---
+
+## 2. High-Level Flow
+
+1. Every incoming backend request is observed by `MonitoringRequestMetricsMiddleware`.
+2. Request metrics are recorded (`route`, `method`, `status_code`, `duration_ms`) except for routes under `monitoring/*`.
+3. Auth endpoints decorated with `@track_auth_metric(...)` emit auth event metrics.
+4. `MonitoringService` serves:
+- `live`: liveness payload.
+- `readiness`: checks + HTTP status mapping.
+- `stats`: aggregated metrics snapshot (with cache).
+- `stats_json`: pre-serialized JSON for SSE efficiency.
+5. Repository backend is `memory` or `redis` (with resilient fallback to memory if Redis fails).
+
+---
+
+## 3. Access Model
+
+Monitoring access is evaluated by `MonitoringAccessPolicy`:
+- `unauthenticated`: no authenticated user.
+- `unverified`: authenticated user but `user.status != "verified"`.
+- `no_account`: verified user without `MonitoringAccount`.
+- `inactive`: monitoring account exists but inactive.
+- `ok`: access granted.
+
+`MonitoringAccount.has_access` is true only if:
+- account is active, and
+- user status is `verified`.
+
+---
+
+## 4. HTTP Endpoints
+
+All routes are defined in `backend/monitoring/interfaces/http/urls.py`.
+
+| Endpoint | Method | Auth | Behavior |
+|---|---|---|---|
+| `/monitoring/live/` | GET | Public | Liveness status + timestamp |
+| `/monitoring/ready/` | GET | Monitoring account required | Readiness checks, returns `200` (`ok`) or `503` (`degraded/down`) |
+| `/monitoring/stats/` | GET | Monitoring account required | Full metrics snapshot |
+| `/monitoring/snapshot/` | GET | JWT optional | Always `200`; unauthorized gets `{access, ready:null, stats:null}` |
+| `/monitoring/stream/` | GET | Monitoring account required | SSE stream (`text/event-stream`) |
+| `/monitoring/access/` | GET | JWT required | Returns access decision (`allowed`, `reason`) |
+
+### Stream query params
+- `interval_seconds`: positive float; invalid/non-positive uses fallback `MONITORING_STREAM_INTERVAL_SECONDS`.
+- `max_events`: positive int; invalid/non-positive ignored (infinite stream).
+
+### Frontend integration summary
+- Monitoring UI route: `/monitoring` (frontend app).
+- Bootstrap strategy: initial load can use authenticated snapshot (`/monitoring/snapshot/`) when available.
+- Live update strategy: after bootstrap, frontend prefers SSE (`/monitoring/stream/`).
+- Polling fallback: periodic refresh runs only when no active SSE stream.
+- Visibility optimization: stream/polling is paused when tab is hidden and resumed when visible again.
+
+---
+
+## 5. Metrics Semantics
+
+### 5.1 Route metrics
+- Error is counted when `status_code >= 400` (includes 4xx and 5xx).
+- Route stats include totals, error rate, avg/max latency, p95, p99.
+- Monitoring routes are excluded from request-metric recording by middleware.
+
+### 5.2 Auth events
+Auth outcomes are resolved from HTTP status:
+- `< 400` -> `success`
+- `400-499` -> `client_error`
+- `>= 500` -> `server_error`
+- exception in view -> `exception`
+
+### 5.3 Realtime series
+- Built from request records in fixed buckets.
+- Defaults: window `300s`, bucket `10s`.
+- Frontend uses the recent points for latency/traffic charting.
+
+---
+
+## 6. Repository Backends
+
+### 6.1 Memory backend
+- Fast local default.
+- Data resets on process restart.
+
+### 6.2 Redis backend
+- Persisted in Redis with key prefix/namespace and optional TTL.
+- Supports route ranking limit and snapshot cache TTL.
+- If Redis init/runtime fails in resilient mode, repository degrades to in-memory fallback.
+
+---
+
+## 7. Readiness Checks
+
+Default checks:
+- `database` (critical)
+- `storage` (critical)
+- `openai_config` (non-critical)
+
+When metrics backend is Redis:
+- `redis` is also checked (non-critical by default).
+
+Readiness status resolution:
+- any critical failure -> `down` (`503`)
+- only non-critical failure(s) -> `degraded` (`503`)
+- all pass -> `ok` (`200`)
+
+---
+
+## 8. Discord Webhook Alerts
+
+Readiness non-OK notifications are sent via `DiscordWebhookNotifier` when configured.
+
+Trigger rules:
+- only for non-`ok` readiness.
+- cooldown applied by `MONITORING_READINESS_ALERT_COOLDOWN_SECONDS`.
+- same status within cooldown is suppressed.
+
+Required config:
+- `MONITORING_DISCORD_WEBHOOK_URL`
+- optional `MONITORING_DISCORD_WEBHOOK_USERNAME` (default `MonitoringBot`)
+- optional `MONITORING_DISCORD_WEBHOOK_TIMEOUT_SECONDS` (default `3.0`)
+
+Implementation detail:
+- notifier sends JSON with `Content-Type: application/json` and explicit `User-Agent`.
+
+---
+
+## 9. Configuration
+
+Defined in `backend/config/settings.py` and consumed in `monitoring/container.py` / views.
+
+### Core
+- `MONITORING_METRICS_BACKEND` (`memory` or `redis`, default `memory`)
+- `MONITORING_STREAM_INTERVAL_SECONDS` (default `2.0`)
+- `MONITORING_STATS_CACHE_TTL_SECONDS` (default `2.0`)
+
+### Realtime and route sampling
+- `MONITORING_REALTIME_WINDOW_SECONDS` (default `300`)
+- `MONITORING_REALTIME_BUCKET_SECONDS` (default `10`)
+- `MONITORING_MAX_REALTIME_RECORDS` (default `10000`)
+- `MONITORING_MAX_ROUTE_LATENCY_SAMPLES` (default `2048`)
+- `MONITORING_MAX_ROUTES_PER_SNAPSHOT` (default `0`, means unlimited)
+
+### Redis
+- `MONITORING_REDIS_URL` (default `redis://127.0.0.1:6379/0`)
+- `MONITORING_REDIS_KEY_PREFIX` (default `monitoring`)
+- `MONITORING_REDIS_KEY_NAMESPACE_VERSION` (default `v1`)
+- `MONITORING_REDIS_KEY_TTL_SECONDS` (default `86400`)
+- `MONITORING_REDIS_SOCKET_TIMEOUT_SECONDS` (default `1.0`)
+- `MONITORING_REDIS_CONNECT_TIMEOUT_SECONDS` (default `1.0`)
+- `MONITORING_REDIS_SNAPSHOT_CACHE_TTL_SECONDS` (optional; if <=0 falls back to `MONITORING_STATS_CACHE_TTL_SECONDS`)
+
+### Readiness alerting
+- `MONITORING_DISCORD_WEBHOOK_URL` (default empty/disabled)
+- `MONITORING_DISCORD_WEBHOOK_USERNAME` (default `MonitoringBot`)
+- `MONITORING_DISCORD_WEBHOOK_TIMEOUT_SECONDS` (default `3.0`)
+- `MONITORING_READINESS_ALERT_COOLDOWN_SECONDS` (default `300`)
+
+### Endpoint rate limiting
+- `MONITORING_RATE_LIMIT_MAX_REQUESTS` (default `120`)
+- `MONITORING_RATE_LIMIT_PER` (`second(s)` or `minute(s)`, default `minute`)
+
+---
+
+## 10. Local Setup and Verification
+
+Run from repo root (`excel-generator-mono`), backend on `localhost:8000`.
+
+### 10.1 Create/activate monitoring account
+
+```bash
+cd backend
+python manage.py shell -c "from authentication.models import User; from monitoring.models import MonitoringAccount; u=User.objects.get(email='monitoring@example.com'); u.status='verified'; u.save(update_fields=['status']); MonitoringAccount.objects.provision_for_user(user=u, is_active=True)"
+```
+
+### 10.2 Login and capture token
+
+```bash
+curl -s -X POST http://localhost:8000/auth/login/ \
+  -H "Content-Type: application/json" \
+  -d '{"email":"monitoring@example.com","password":"your-password"}'
+```
+
+Use returned `access_token` as `TOKEN`.
+
+### 10.3 Test endpoints
+
+```bash
+curl -s http://localhost:8000/monitoring/live/
+curl -s -H "Authorization: Bearer TOKEN" http://localhost:8000/monitoring/access/
+curl -s -H "Authorization: Bearer TOKEN" http://localhost:8000/monitoring/snapshot/
+curl -N -H "Authorization: Bearer TOKEN" -H "Accept: text/event-stream" "http://localhost:8000/monitoring/stream/?interval_seconds=5&max_events=3"
+```
+
+### 10.4 Compare with normal user (no monitoring account)
+
+```bash
+curl -s -H "Authorization: Bearer NORMAL_USER_TOKEN" http://localhost:8000/monitoring/access/
+curl -s -i -H "Authorization: Bearer NORMAL_USER_TOKEN" http://localhost:8000/monitoring/stats/
+curl -s -H "Authorization: Bearer NORMAL_USER_TOKEN" http://localhost:8000/monitoring/snapshot/
+```
+
+Expected:
+- `/monitoring/access/` -> `allowed: false`, reason typically `no_account` or `unverified`.
+- `/monitoring/stats/` -> `403`.
+- `/monitoring/snapshot/` -> `200` with `ready: null` and `stats: null`.
+
+---
+
+## 11. Troubleshooting
+
+### `401` on protected endpoints
+- Missing/invalid JWT.
+- Check `Authorization: Bearer <token>`.
+
+### `403` for authenticated user
+- User is not verified, or no `MonitoringAccount`, or account inactive.
+- Check `/monitoring/access/` reason.
+
+### `404` for `/monitoring/stream/` from frontend
+- Frontend may be calling its own dev server route.
+- Verify `NEXT_PUBLIC_API_URL` points to backend API host.
+
+### `406 Not Acceptable` when testing stream
+- Send `Accept: text/event-stream`.
+
+### No route metrics shown
+- Monitoring routes are intentionally excluded.
+- Generate normal API traffic first (non-`/monitoring/*` endpoints).
+
+### Redis connection errors
+- If backend is `redis`, ensure Redis is running and reachable.
+- If Redis fails at startup in resilient path, service falls back to memory repository.
+
+### Auth events mismatch with route row
+- Route metrics aggregate HTTP status by route (`>=400` counts as error).
+- Auth event outcome uses decorated auth endpoints and outcome mapping by response status/exception.

--- a/backend/monitoring/infrastructure/discord_notifier.py
+++ b/backend/monitoring/infrastructure/discord_notifier.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 DiscordPayload: TypeAlias = dict[str, object]
 DiscordPostCallable: TypeAlias = Callable[..., None]
+DEFAULT_DISCORD_WEBHOOK_USER_AGENT = "excel-generator-mono-monitoring/1.0"
 
 
 def _post_to_discord_webhook(
@@ -21,7 +22,10 @@ def _post_to_discord_webhook(
     request = Request(
         webhook_url,
         data=json.dumps(payload).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": DEFAULT_DISCORD_WEBHOOK_USER_AGENT,
+        },
         method="POST",
     )
     with urlopen(request, timeout=timeout_seconds) as response:

--- a/backend/monitoring/infrastructure/repositories.py
+++ b/backend/monitoring/infrastructure/repositories.py
@@ -73,7 +73,7 @@ class _RouteAccumulator:
             self.latency_samples.popleft()
         self.precomputed_p95_latency_ms = None
         self.precomputed_p99_latency_ms = None
-        if event.status_code >= 500:
+        if event.status_code >= 400:
             self.total_errors += 1
 
     def to_snapshot(self, route: str, method: str) -> RouteMetricSnapshot:
@@ -538,7 +538,7 @@ class InMemoryMetricsRepository(_MetricKeyNormalizerMixin, _RepositoryRealtimeMi
         self._recent_requests.append(
             _RealtimeRequestRecord(
                 created_at=event.created_at,
-                is_error=event.status_code >= 500,
+                is_error=event.status_code >= 400,
                 duration_ms=max(0.0, float(event.duration_ms)),
             )
         )
@@ -730,7 +730,7 @@ class RedisMetricsRepository(_MetricKeyNormalizerMixin, _RepositoryRealtimeMixin
         route_hash_key = self._route_hash_key(route=route, method=method)
         route_latency_samples_key = self._route_latency_samples_key(route_hash_key)
         duration_ms = max(0.0, float(event.duration_ms))
-        is_error = 1 if event.status_code >= 500 else 0
+        is_error = 1 if event.status_code >= 400 else 0
         now_epoch = self._realtime_series_builder.to_epoch_seconds(self._now())
         created_epoch = self._realtime_series_builder.to_epoch_seconds(event.created_at)
 

--- a/backend/monitoring/interfaces/http/middleware.py
+++ b/backend/monitoring/interfaces/http/middleware.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_ERROR_STATUS = 500
 DEFAULT_UNKNOWN_METHOD = "UNKNOWN"
 DEFAULT_UNKNOWN_PATH = "unknown"
+MONITORING_ROUTE_PREFIX = "monitoring/"
 
 
 class MonitoringRequestMetricsMiddleware:
@@ -30,6 +31,8 @@ class MonitoringRequestMetricsMiddleware:
 
     def _record_request_metrics(self, *, request, status_code: int, duration_ms: float) -> None:
         route = self._resolve_route(request)
+        if self._is_monitoring_route(route):
+            return
         method = self._resolve_method(request)
         try:
             get_monitoring_service().record_request(
@@ -51,6 +54,11 @@ class MonitoringRequestMetricsMiddleware:
     @staticmethod
     def _resolve_method(request) -> str:
         return str(getattr(request, "method", DEFAULT_UNKNOWN_METHOD))
+
+    @staticmethod
+    def _is_monitoring_route(route: str) -> bool:
+        normalized_route = route.strip().lstrip("/").lower()
+        return normalized_route.startswith(MONITORING_ROUTE_PREFIX)
 
     @staticmethod
     def _resolve_status_code(response) -> int:

--- a/backend/monitoring/tests/test_container.py
+++ b/backend/monitoring/tests/test_container.py
@@ -45,6 +45,12 @@ class MonitoringContainerTest(SimpleTestCase):
             container._build_repository_kwargs()["max_routes_per_snapshot"]
         )
 
+    @override_settings(MONITORING_MAX_ROUTES_PER_SNAPSHOT="0")
+    def test_build_repository_kwargs_ignores_non_positive_routes_setting(self):
+        self.assertIsNone(
+            container._build_repository_kwargs()["max_routes_per_snapshot"]
+        )
+
     @override_settings(
         MONITORING_REDIS_SNAPSHOT_CACHE_TTL_SECONDS=0,
         MONITORING_STATS_CACHE_TTL_SECONDS=4.5,

--- a/backend/monitoring/tests/test_discord_notifier.py
+++ b/backend/monitoring/tests/test_discord_notifier.py
@@ -130,4 +130,8 @@ class DiscordWebhookNotifierTest(SimpleTestCase):
             request_headers.get("Content-Type", request_headers.get("Content-type")),
             "application/json",
         )
+        self.assertEqual(
+            request_headers.get("User-Agent", request_headers.get("User-agent")),
+            "excel-generator-mono-monitoring/1.0",
+        )
         self.assertEqual(json.loads(request_capture.data.decode("utf-8")), payload)

--- a/backend/monitoring/tests/test_middleware.py
+++ b/backend/monitoring/tests/test_middleware.py
@@ -81,3 +81,33 @@ class MonitoringRequestMetricsMiddlewareTest(SimpleTestCase):
 
         self.assertEqual(route, "/fallback/")
 
+    @patch("monitoring.interfaces.http.middleware.get_monitoring_service")
+    def test_middleware_skips_recording_for_monitoring_route(self, mocked_get_service):
+        monitoring_service = Mock()
+        mocked_get_service.return_value = monitoring_service
+
+        middleware = MonitoringRequestMetricsMiddleware(
+            lambda request: HttpResponse(status=200)
+        )
+        request = self.factory.get("/monitoring/stats/")
+        request.resolver_match = SimpleNamespace(route="monitoring/stats/")
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        monitoring_service.record_request.assert_not_called()
+
+    @patch("monitoring.interfaces.http.middleware.get_monitoring_service")
+    def test_middleware_skips_recording_for_monitoring_path_fallback(self, mocked_get_service):
+        monitoring_service = Mock()
+        mocked_get_service.return_value = monitoring_service
+
+        middleware = MonitoringRequestMetricsMiddleware(
+            lambda request: HttpResponse(status=200)
+        )
+        request = self.factory.get("/monitoring/ready/")
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        monitoring_service.record_request.assert_not_called()

--- a/backend/monitoring/tests/test_repositories.py
+++ b/backend/monitoring/tests/test_repositories.py
@@ -214,6 +214,17 @@ class InMemoryMetricsRepositoryTest(SimpleTestCase):
             1,
         )
 
+    def test_record_request_counts_client_errors_in_route_totals(self):
+        self.repo.record_request(self._event(status_code=401, duration_ms=100.0))
+
+        snapshot = self.repo.get_snapshot()
+        self.assertEqual(snapshot.total_errors, 1)
+        self.assertEqual(snapshot.routes[0].total_errors, 1)
+        self.assertEqual(
+            sum(point.errors for point in snapshot.timeseries),
+            1,
+        )
+
     def test_record_request_normalizes_empty_route_and_method(self):
         self.repo.record_request(self._event(route=" ", method=" ", duration_ms=10.0))
 
@@ -1233,6 +1244,17 @@ class RedisMetricsRepositoryTest(SimpleTestCase):
             2,
         )
         self.assertTrue(any(key.startswith("monitoring_test:v2:") for key in self.redis_client._expirations))
+
+    def test_record_request_counts_client_errors_in_route_totals(self):
+        self.repo.record_request(self._event(status_code=401, duration_ms=90.0))
+
+        snapshot = self.repo.get_snapshot()
+        self.assertEqual(snapshot.total_errors, 1)
+        self.assertEqual(snapshot.routes[0].total_errors, 1)
+        self.assertEqual(
+            sum(point.errors for point in snapshot.timeseries),
+            1,
+        )
 
     def test_normalization_and_reset(self):
         self.repo.record_request(self._event(route=" ", method=" ", duration_ms=-1.0))

--- a/frontend/src/app/monitoring/MonitoringPage.tsx
+++ b/frontend/src/app/monitoring/MonitoringPage.tsx
@@ -145,9 +145,8 @@ export default function MonitoringPage({ monitoringService = defaultMonitoringSe
                     {errorMessage ? (
                         <div
                             role="alert"
-                            className="flex items-start gap-2 rounded-lg border border-red-400 bg-red-50 p-3 text-sm text-red-700"
+                            className="rounded-lg border border-red-400 bg-red-50 p-3 text-sm text-red-700"
                         >
-                            <span aria-hidden>!</span>
                             <div className="space-y-1">
                                 <p>{errorMessage}</p>
                                 {retryInSeconds > 0 ? (

--- a/frontend/src/app/monitoring/components/MonitoringDashboardSections.tsx
+++ b/frontend/src/app/monitoring/components/MonitoringDashboardSections.tsx
@@ -5,7 +5,13 @@ import type {
     MonitoringReadyPayload,
     MonitoringStatsPayload,
 } from '@/services/monitoring'
-import { formatPercent, formatTimestamp, resolveAccessMessage } from '../monitoringUi'
+import {
+    formatPercent,
+    formatReadinessCheckName,
+    formatStatusLabel,
+    formatTimestamp,
+    resolveAccessMessage,
+} from '../monitoringUi'
 import type {
     ErrorRateMeter,
     EventRow,
@@ -15,6 +21,13 @@ import type {
     RealtimeTotals,
 } from '../monitoringViewModelTypes'
 import { GaugeMeter, MetricCard, StatusBadge } from './primitives/MonitoringPrimitives'
+
+const MONITORING_ROUTE_PREFIX = 'monitoring/'
+
+function isMonitoringRoute(route: string): boolean {
+    const normalizedRoute = route.trim().replace(/^\/+/, '').toLowerCase()
+    return normalizedRoute.startsWith(MONITORING_ROUTE_PREFIX)
+}
 
 type MonitoringHeroSectionProps = Readonly<{
     lastSync: string
@@ -43,7 +56,7 @@ export function MonitoringHeroSection({
                     <div>
                         <h1 className="text-2xl font-bold tracking-tight text-white">System Monitoring</h1>
                         <p className="mt-2 max-w-2xl text-sm text-gray-300">
-                            Grafana-inspired live health, readiness, traffic, and auth activity for your backend.
+                            Live health, readiness, traffic, and auth activity for your backend.
                         </p>
                     </div>
                 </div>
@@ -56,11 +69,7 @@ export function MonitoringHeroSection({
                                 <span className="inline-flex rounded-full border border-red-300/40 bg-red-700/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-red-200">
                                     Stale Data
                                 </span>
-                            ) : (
-                                <span className="inline-flex rounded-full border border-blue-300/40 bg-blue-600/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-blue-100">
-                                    Live
-                                </span>
-                            )}
+                            ) : null}
                             {retryInSeconds > 0 ? (
                                 <span className="text-xs text-gray-300">Retry in {retryInSeconds}s</span>
                             ) : null}
@@ -111,14 +120,14 @@ export function MonitoringTrafficSummarySection({
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
                 <MetricCard
                     title="Live Status"
-                    value={<StatusBadge status={livePayload.status} label={livePayload.status} />}
+                    value={<StatusBadge status={livePayload.status} label={formatStatusLabel(livePayload.status)} />}
                     valueClassName="text-base"
                     subtitle={formatTimestamp(livePayload.timestamp)}
                 />
 
                 <MetricCard
                     title="Access"
-                    value={<StatusBadge status={accessDecision.allowed ? 'success' : 'error'} label={accessDecision.allowed ? 'allowed' : 'denied'} />}
+                    value={<StatusBadge status={accessDecision.allowed ? 'success' : 'error'} label={accessDecision.allowed ? 'Allowed' : 'Denied'} />}
                     valueClassName="text-base"
                     subtitle={resolveAccessMessage(accessDecision.reason)}
                 />
@@ -195,7 +204,7 @@ export function MonitoringReadinessAlertSection({
                             key={`${check.name}:${check.status}`}
                             className="rounded-lg border border-amber-200 bg-amber-100/50 px-3 py-2"
                         >
-                            <span className="font-semibold">{check.name}</span>: {check.status}
+                            <span className="font-semibold">{formatReadinessCheckName(check.name)}</span>: {formatStatusLabel(check.status)}
                             {check.message ? <span className="text-amber-900"> - {check.message}</span> : null}
                         </li>
                     ))
@@ -231,6 +240,11 @@ export function MonitoringLatencyAndMetersSection({
         : 'Latency trend for the top monitored routes from the latest snapshot.'
     const latestLatencyPoint = latencySeries.at(-1)
     const lastLatencyEntry = latestLatencyPoint
+    const maxRequestsInSeries = Math.max(0, ...latencySeries.map((entry) => entry.requests ?? 0))
+    const yAxisTopMs = Math.max(1, latencyChart.maxLatency)
+    const yAxisMidMs = yAxisTopMs / 2
+    const yAxisTopLabel = yAxisTopMs < 10 ? `${yAxisTopMs.toFixed(1)}ms` : `${yAxisTopMs.toFixed(0)}ms`
+    const yAxisMidLabel = yAxisMidMs < 10 ? `${yAxisMidMs.toFixed(1)}ms` : `${yAxisMidMs.toFixed(0)}ms`
 
     return (
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-12">
@@ -247,6 +261,9 @@ export function MonitoringLatencyAndMetersSection({
                 ) : (
                     <>
                         <div className="mt-4 overflow-x-auto rounded-xl border border-gray-200 bg-gray-50 p-3">
+                            <p className="mb-2 text-xs text-gray-500">
+                                Y-axis: Avg latency (ms). Max requests in series: {maxRequestsInSeries}
+                            </p>
                             <svg
                                 viewBox="0 0 520 220"
                                 className="h-52 w-full min-w-[520px]"
@@ -257,6 +274,15 @@ export function MonitoringLatencyAndMetersSection({
                                 <desc id={lineChartDescId}>{lineChartDescription}</desc>
                                 <line x1="26" y1="190" x2="494" y2="190" stroke="#d1d5db" strokeWidth="1" />
                                 <line x1="26" y1="16" x2="26" y2="190" stroke="#d1d5db" strokeWidth="1" />
+                                <text x="4" y="20" fontSize="11" fill="#6b7280">
+                                    {yAxisTopLabel}
+                                </text>
+                                <text x="4" y="104" fontSize="11" fill="#6b7280">
+                                    {yAxisMidLabel}
+                                </text>
+                                <text x="16" y="194" fontSize="11" fill="#6b7280">
+                                    0
+                                </text>
                                 {latencyChart.areaPath ? (
                                     <path
                                         d={latencyChart.areaPath}
@@ -381,15 +407,17 @@ export function MonitoringRoutesAndReadinessSection({
     maxRouteRequests,
     readyPayload,
 }: MonitoringRoutesAndReadinessSectionProps) {
+    const visibleRoutes = statsPayload.routes.filter((routeRow) => !isMonitoringRoute(routeRow.route))
+
     return (
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-12">
             <article className="rounded-2xl border border-gray-200 bg-white p-5 shadow-md lg:col-span-8">
                 <h3 className="text-base font-semibold text-gray-900">Top Routes</h3>
-                {statsPayload.routes.length === 0 ? (
+                {visibleRoutes.length === 0 ? (
                     <p className="mt-3 text-sm text-gray-600">No route metrics available yet.</p>
                 ) : (
                     <div className="mt-4 space-y-3">
-                        {statsPayload.routes.slice(0, 6).map((routeRow) => {
+                        {visibleRoutes.slice(0, 6).map((routeRow) => {
                             const requestWidth = `${Math.max(
                                 8,
                                 Math.round((routeRow.total_requests / maxRouteRequests) * 100)
@@ -426,7 +454,7 @@ export function MonitoringRoutesAndReadinessSection({
                 <h3 className="text-base font-semibold text-gray-900">Readiness Checks</h3>
                 {readyPayload ? (
                     <div className="mt-4 space-y-3">
-                        <StatusBadge status={readyPayload.status} label={readyPayload.status} />
+                        <StatusBadge status={readyPayload.status} label={formatStatusLabel(readyPayload.status)} />
                         <p className="text-sm text-gray-500">
                             Timestamp: {formatTimestamp(readyPayload.timestamp)}
                         </p>
@@ -437,10 +465,10 @@ export function MonitoringRoutesAndReadinessSection({
                                     className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2"
                                 >
                                     <div className="flex items-center justify-between text-sm">
-                                        <span className="font-semibold text-gray-900">{check.name}</span>
+                                        <span className="font-semibold text-gray-900">{formatReadinessCheckName(check.name)}</span>
                                         <StatusBadge
                                             status={check.status}
-                                            label={check.status}
+                                            label={formatStatusLabel(check.status)}
                                             className="px-2 py-0.5 text-xs"
                                         />
                                     </div>

--- a/frontend/src/app/monitoring/components/MonitoringDashboardSections.tsx
+++ b/frontend/src/app/monitoring/components/MonitoringDashboardSections.tsx
@@ -224,6 +224,186 @@ type MonitoringLatencyAndMetersSectionProps = Readonly<{
     readinessMeter: ReadinessMeter
 }>
 
+type LatencyChartPanelProps = Readonly<{
+    latencySeries: LatencySeriesPoint[]
+    latencyChart: LatencyChartModel
+    hasRealtimeSeries: boolean
+    realtimeWindowSeconds: number
+    realtimeBucketSeconds: number
+}>
+
+function formatLatencyAxisLabel(value: number): string {
+    return value < 10 ? `${value.toFixed(1)}ms` : `${value.toFixed(0)}ms`
+}
+
+function resolveLatencyChartDescription(
+    hasRealtimeSeries: boolean,
+    realtimeWindowSeconds: number,
+    realtimeBucketSeconds: number,
+): string {
+    if (!hasRealtimeSeries || realtimeWindowSeconds <= 0) {
+        return 'Latency trend for the top monitored routes from the latest snapshot.'
+    }
+
+    return `Latency trend over ${realtimeWindowSeconds} seconds, grouped every ${realtimeBucketSeconds} seconds.`
+}
+
+function shouldShowLatencyPointLabel(
+    seriesLength: number,
+    index: number,
+    isLastEntry: boolean,
+): boolean {
+    if (seriesLength <= 6) {
+        return true
+    }
+    if (isLastEntry) {
+        return true
+    }
+    return index % 2 === 0
+}
+
+function LatencyChartPanel({
+    latencySeries,
+    latencyChart,
+    hasRealtimeSeries,
+    realtimeWindowSeconds,
+    realtimeBucketSeconds,
+}: LatencyChartPanelProps) {
+    const lineChartTitleId = useId()
+    const lineChartDescId = useId()
+    const lineChartDescription = resolveLatencyChartDescription(
+        hasRealtimeSeries,
+        realtimeWindowSeconds,
+        realtimeBucketSeconds,
+    )
+    const latestLatencyPoint = latencySeries.at(-1)
+    const maxRequestsInSeries = Math.max(0, ...latencySeries.map((entry) => entry.requests ?? 0))
+    const yAxisTopMs = Math.max(1, latencyChart.maxLatency)
+    const yAxisMidMs = yAxisTopMs / 2
+    const yAxisTopLabel = formatLatencyAxisLabel(yAxisTopMs)
+    const yAxisMidLabel = formatLatencyAxisLabel(yAxisMidMs)
+    const latencyModeLabel = hasRealtimeSeries ? `Realtime ${realtimeBucketSeconds}s Buckets` : 'Avg Route Latency'
+    const peakLatencyContextLabel = hasRealtimeSeries && realtimeWindowSeconds > 0
+        ? `Peak latency in last ${realtimeWindowSeconds}s:`
+        : 'Peak observed latency in this snapshot:'
+
+    return (
+        <article className="rounded-2xl border border-gray-200 bg-white p-5 shadow-md lg:col-span-8">
+            <div className="flex items-center justify-between gap-3">
+                <h3 className="text-base font-semibold text-gray-900">Latency Line Chart</h3>
+                <span className="text-xs font-semibold uppercase tracking-[0.12em] text-gray-500">
+                    {latencyModeLabel}
+                </span>
+            </div>
+
+            {latencySeries.length === 0 ? (
+                <p className="mt-4 text-sm text-gray-600">No latency data available yet.</p>
+            ) : (
+                <>
+                    <div className="mt-4 overflow-x-auto rounded-xl border border-gray-200 bg-gray-50 p-3">
+                        <p className="mb-2 text-xs text-gray-500">
+                            Y-axis: Avg latency (ms). Max requests in series: {maxRequestsInSeries}
+                        </p>
+                        <svg
+                            viewBox="0 0 520 220"
+                            className="h-52 w-full min-w-[520px]"
+                            aria-labelledby={`${lineChartTitleId} ${lineChartDescId}`}
+                            tabIndex={0}
+                        >
+                            <title id={lineChartTitleId}>Latency trend line chart</title>
+                            <desc id={lineChartDescId}>{lineChartDescription}</desc>
+                            <line x1="26" y1="190" x2="494" y2="190" stroke="#d1d5db" strokeWidth="1" />
+                            <line x1="26" y1="16" x2="26" y2="190" stroke="#d1d5db" strokeWidth="1" />
+                            <text x="4" y="20" fontSize="11" fill="#6b7280">
+                                {yAxisTopLabel}
+                            </text>
+                            <text x="4" y="104" fontSize="11" fill="#6b7280">
+                                {yAxisMidLabel}
+                            </text>
+                            <text x="16" y="194" fontSize="11" fill="#6b7280">
+                                0
+                            </text>
+                            {latencyChart.areaPath ? (
+                                <path
+                                    d={latencyChart.areaPath}
+                                    fill="#dbeafe"
+                                    fillOpacity="0.6"
+                                />
+                            ) : null}
+                            {latencyChart.linePoints ? (
+                                <polyline
+                                    points={latencyChart.linePoints}
+                                    fill="none"
+                                    stroke="#2563eb"
+                                    strokeWidth="3"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                />
+                            ) : null}
+                            {latencySeries.map((entry, index) => {
+                                const normalizedX = latencySeries.length === 1 ? 0.5 : index / (latencySeries.length - 1)
+                                const normalizedY = Math.min(
+                                    1,
+                                    Math.max(0, entry.value / Math.max(1, latencyChart.maxLatency))
+                                )
+                                const x = 26 + normalizedX * (520 - 52)
+                                const y = 16 + (1 - normalizedY) * (220 - 46)
+                                const showLabel = shouldShowLatencyPointLabel(
+                                    latencySeries.length,
+                                    index,
+                                    entry === latestLatencyPoint,
+                                )
+                                const xLabel = hasRealtimeSeries ? entry.label : String(entry.id)
+
+                                return (
+                                    <g key={entry.id}>
+                                        <circle cx={x} cy={y} r="4" fill="#2563eb" />
+                                        <text
+                                            x={x}
+                                            y="208"
+                                            textAnchor="middle"
+                                            fontSize="11"
+                                            fill="#6b7280"
+                                        >
+                                            {showLabel ? xLabel : ''}
+                                        </text>
+                                    </g>
+                                )
+                            })}
+                        </svg>
+                    </div>
+
+                    <p className="mt-3 text-sm text-gray-600">
+                        {peakLatencyContextLabel}{' '}
+                        <span className="font-semibold text-gray-900">{latencyChart.maxLatency.toFixed(2)} ms</span>
+                    </p>
+                    {hasRealtimeSeries ? (
+                        <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                            Latest bucket {latestLatencyPoint?.label}: avg latency{' '}
+                            <span className="font-semibold text-gray-900">
+                                {latestLatencyPoint?.value.toFixed(2)} ms
+                            </span>{' '}
+                            across{' '}
+                            <span className="font-semibold text-gray-900">
+                                {latestLatencyPoint?.requests ?? 0}
+                            </span>{' '}
+                            requests.
+                        </div>
+                    ) : (
+                        <ul className="mt-3 grid grid-cols-1 gap-2 text-xs text-gray-600 sm:grid-cols-2">
+                            {latencySeries.map((entry) => (
+                                <li key={entry.id} className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+                                    <span className="font-semibold text-gray-900">[{entry.id}]</span> {entry.label}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </>
+            )}
+        </article>
+    )
+}
+
 export function MonitoringLatencyAndMetersSection({
     latencySeries,
     latencyChart,
@@ -233,139 +413,15 @@ export function MonitoringLatencyAndMetersSection({
     errorRateMeter,
     readinessMeter,
 }: MonitoringLatencyAndMetersSectionProps) {
-    const lineChartTitleId = useId()
-    const lineChartDescId = useId()
-    const lineChartDescription = hasRealtimeSeries && realtimeWindowSeconds > 0
-        ? `Latency trend over ${realtimeWindowSeconds} seconds, grouped every ${realtimeBucketSeconds} seconds.`
-        : 'Latency trend for the top monitored routes from the latest snapshot.'
-    const latestLatencyPoint = latencySeries.at(-1)
-    const lastLatencyEntry = latestLatencyPoint
-    const maxRequestsInSeries = Math.max(0, ...latencySeries.map((entry) => entry.requests ?? 0))
-    const yAxisTopMs = Math.max(1, latencyChart.maxLatency)
-    const yAxisMidMs = yAxisTopMs / 2
-    const yAxisTopLabel = yAxisTopMs < 10 ? `${yAxisTopMs.toFixed(1)}ms` : `${yAxisTopMs.toFixed(0)}ms`
-    const yAxisMidLabel = yAxisMidMs < 10 ? `${yAxisMidMs.toFixed(1)}ms` : `${yAxisMidMs.toFixed(0)}ms`
-
     return (
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-12">
-            <article className="rounded-2xl border border-gray-200 bg-white p-5 shadow-md lg:col-span-8">
-                <div className="flex items-center justify-between gap-3">
-                    <h3 className="text-base font-semibold text-gray-900">Latency Line Chart</h3>
-                    <span className="text-xs font-semibold uppercase tracking-[0.12em] text-gray-500">
-                        {hasRealtimeSeries ? `Realtime ${realtimeBucketSeconds}s Buckets` : 'Avg Route Latency'}
-                    </span>
-                </div>
-
-                {latencySeries.length === 0 ? (
-                    <p className="mt-4 text-sm text-gray-600">No latency data available yet.</p>
-                ) : (
-                    <>
-                        <div className="mt-4 overflow-x-auto rounded-xl border border-gray-200 bg-gray-50 p-3">
-                            <p className="mb-2 text-xs text-gray-500">
-                                Y-axis: Avg latency (ms). Max requests in series: {maxRequestsInSeries}
-                            </p>
-                            <svg
-                                viewBox="0 0 520 220"
-                                className="h-52 w-full min-w-[520px]"
-                                aria-labelledby={`${lineChartTitleId} ${lineChartDescId}`}
-                                tabIndex={0}
-                            >
-                                <title id={lineChartTitleId}>Latency trend line chart</title>
-                                <desc id={lineChartDescId}>{lineChartDescription}</desc>
-                                <line x1="26" y1="190" x2="494" y2="190" stroke="#d1d5db" strokeWidth="1" />
-                                <line x1="26" y1="16" x2="26" y2="190" stroke="#d1d5db" strokeWidth="1" />
-                                <text x="4" y="20" fontSize="11" fill="#6b7280">
-                                    {yAxisTopLabel}
-                                </text>
-                                <text x="4" y="104" fontSize="11" fill="#6b7280">
-                                    {yAxisMidLabel}
-                                </text>
-                                <text x="16" y="194" fontSize="11" fill="#6b7280">
-                                    0
-                                </text>
-                                {latencyChart.areaPath ? (
-                                    <path
-                                        d={latencyChart.areaPath}
-                                        fill="#dbeafe"
-                                        fillOpacity="0.6"
-                                    />
-                                ) : null}
-                                {latencyChart.linePoints ? (
-                                    <polyline
-                                        points={latencyChart.linePoints}
-                                        fill="none"
-                                        stroke="#2563eb"
-                                        strokeWidth="3"
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                    />
-                                ) : null}
-                                {latencySeries.map((entry, index) => {
-                                    const normalizedX = latencySeries.length === 1 ? 0.5 : index / (latencySeries.length - 1)
-                                    const normalizedY = Math.min(
-                                        1,
-                                        Math.max(0, entry.value / Math.max(1, latencyChart.maxLatency))
-                                    )
-                                    const x = 26 + normalizedX * (520 - 52)
-                                    const y = 16 + (1 - normalizedY) * (220 - 46)
-                                    const showLabel = latencySeries.length <= 6 || index % 2 === 0 || entry === lastLatencyEntry
-                                    const xLabel = hasRealtimeSeries ? entry.label : String(entry.id)
-
-                                    return (
-                                        <g key={entry.id}>
-                                            <circle cx={x} cy={y} r="4" fill="#2563eb" />
-                                            <text
-                                                x={x}
-                                                y="208"
-                                                textAnchor="middle"
-                                                fontSize="11"
-                                                fill="#6b7280"
-                                            >
-                                                {showLabel ? xLabel : ''}
-                                            </text>
-                                        </g>
-                                    )
-                                })}
-                            </svg>
-                        </div>
-
-                        <p className="mt-3 text-sm text-gray-600">
-                            {hasRealtimeSeries && realtimeWindowSeconds > 0 ? (
-                                <>
-                                    Peak latency in last {realtimeWindowSeconds}s:{' '}
-                                    <span className="font-semibold text-gray-900">{latencyChart.maxLatency.toFixed(2)} ms</span>
-                                </>
-                            ) : (
-                                <>
-                                    Peak observed latency in this snapshot:{' '}
-                                    <span className="font-semibold text-gray-900">{latencyChart.maxLatency.toFixed(2)} ms</span>
-                                </>
-                            )}
-                        </p>
-                        {hasRealtimeSeries ? (
-                            <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
-                                Latest bucket {latestLatencyPoint?.label}: avg latency{' '}
-                                <span className="font-semibold text-gray-900">
-                                    {latestLatencyPoint?.value.toFixed(2)} ms
-                                </span>{' '}
-                                across{' '}
-                                <span className="font-semibold text-gray-900">
-                                    {latestLatencyPoint?.requests ?? 0}
-                                </span>{' '}
-                                requests.
-                            </div>
-                        ) : (
-                            <ul className="mt-3 grid grid-cols-1 gap-2 text-xs text-gray-600 sm:grid-cols-2">
-                                {latencySeries.map((entry) => (
-                                    <li key={entry.id} className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
-                                        <span className="font-semibold text-gray-900">[{entry.id}]</span> {entry.label}
-                                    </li>
-                                ))}
-                            </ul>
-                        )}
-                    </>
-                )}
-            </article>
+            <LatencyChartPanel
+                latencySeries={latencySeries}
+                latencyChart={latencyChart}
+                hasRealtimeSeries={hasRealtimeSeries}
+                realtimeWindowSeconds={realtimeWindowSeconds}
+                realtimeBucketSeconds={realtimeBucketSeconds}
+            />
 
             <article className="rounded-2xl border border-gray-200 bg-white p-5 shadow-md lg:col-span-4">
                 <h3 className="text-base font-semibold text-gray-900">Meter Panels</h3>

--- a/frontend/src/app/monitoring/monitoringUi.ts
+++ b/frontend/src/app/monitoring/monitoringUi.ts
@@ -6,6 +6,12 @@ const ACCESS_REASON_MESSAGES: Record<string, string> = {
     ok: 'Monitoring access granted.',
 }
 
+const CHECK_NAME_LABELS: Record<string, string> = {
+    database: 'Database',
+    storage: 'Storage',
+    openai_config: 'LLM Config',
+}
+
 export function formatTimestamp(value: string): string {
     const parsed = new Date(value)
     if (Number.isNaN(parsed.getTime())) {
@@ -58,6 +64,22 @@ export function statusBadgeClass(status: string): string {
     return 'border border-gray-300 bg-gray-100 text-gray-700'
 }
 
+export function formatStatusLabel(status: string): string {
+    const normalizedStatus = status.toLowerCase()
+    if (normalizedStatus === 'ok') {
+        return 'OK'
+    }
+    if (normalizedStatus === 'error') {
+        return 'Error'
+    }
+    return status
+}
+
+export function formatReadinessCheckName(name: string): string {
+    const normalizedName = name.trim().toLowerCase()
+    return CHECK_NAME_LABELS[normalizedName] ?? name
+}
+
 export function resolveAccessMessage(reason: string): string {
     return ACCESS_REASON_MESSAGES[reason] ?? `Access status: ${reason}`
 }
@@ -65,4 +87,3 @@ export function resolveAccessMessage(reason: string): string {
 export function clamp(value: number, min: number, max: number): number {
     return Math.min(max, Math.max(min, value))
 }
-

--- a/frontend/src/app/monitoring/useMonitoringDashboardModel.ts
+++ b/frontend/src/app/monitoring/useMonitoringDashboardModel.ts
@@ -17,7 +17,7 @@ import type {
     ReadinessMeter,
     RealtimeTotals,
 } from './monitoringViewModelTypes'
-import { getMonitoringAuthToken } from '@/services/monitoring'
+import { getMonitoringAuthToken, MONITORING_STREAM_UNEXPECTED_CLOSE_MESSAGE } from '@/services/monitoring'
 
 const DEFAULT_AUTO_REFRESH_INTERVAL_MS = 5000
 const STALE_THRESHOLD_MULTIPLIER = 3
@@ -25,6 +25,8 @@ const MIN_STALE_THRESHOLD_MS = 15000
 const RETRY_BASE_DELAY_MS = 2000
 const RETRY_MAX_DELAY_MS = 30000
 const RETRY_TICK_INTERVAL_MS = 1000
+const MAX_REALTIME_LATENCY_TICKS = 6
+const MONITORING_ROUTE_PREFIX = 'monitoring/'
 
 export type MonitoringDashboardService = {
     getMonitoringLive: () => Promise<MonitoringLivePayload>
@@ -72,6 +74,11 @@ function calculateRetryDelayMs(consecutiveFailures: number): number {
         RETRY_MAX_DELAY_MS,
         RETRY_BASE_DELAY_MS * (2 ** Math.max(0, consecutiveFailures - 1))
     )
+}
+
+function isMonitoringRoute(route: string): boolean {
+    const normalizedRoute = route.trim().replace(/^\/+/, '').toLowerCase()
+    return normalizedRoute.startsWith(MONITORING_ROUTE_PREFIX)
 }
 
 export function getIsPageVisible(): boolean {
@@ -188,7 +195,8 @@ export function useMonitoringDashboardModel({
                 if (!isMountedRef.current) {
                     return
                 }
-                setErrorMessage(error.message)
+                const isUnexpectedStreamClose = error.message === MONITORING_STREAM_UNEXPECTED_CLOSE_MESSAGE
+                setErrorMessage(isUnexpectedStreamClose ? null : error.message)
                 stopMonitoringStatsStream()
                 scheduleRetry(Date.now())
             },
@@ -402,13 +410,14 @@ export function useMonitoringDashboardModel({
     }, [statsPayload])
 
     const maxRouteRequests = useMemo(() => {
-        if (!statsPayload || statsPayload.routes.length === 0) {
+        const visibleRoutes = statsPayload?.routes.filter((routeRow) => !isMonitoringRoute(routeRow.route)) ?? []
+        if (visibleRoutes.length === 0) {
             return 1
         }
 
         return Math.max(
             1,
-            ...statsPayload.routes.map((routeRow) => routeRow.total_requests)
+            ...visibleRoutes.map((routeRow) => routeRow.total_requests)
         )
     }, [statsPayload])
 
@@ -422,12 +431,25 @@ export function useMonitoringDashboardModel({
 
     const timeseriesPoints = useMemo(() => {
         const points = statsPayload?.timeseries?.points ?? []
-        return points.filter((point) => point !== null && point !== undefined)
+        const validPoints = points.filter((point) => point !== null && point !== undefined)
+        return validPoints.slice(-MAX_REALTIME_LATENCY_TICKS)
     }, [statsPayload])
 
-    const realtimeWindowSeconds = statsPayload?.timeseries?.window_seconds ?? 0
+    const rawRealtimeWindowSeconds = statsPayload?.timeseries?.window_seconds ?? 0
     const realtimeBucketSeconds = statsPayload?.timeseries?.bucket_seconds ?? 0
     const hasRealtimeSeries = timeseriesPoints.length > 0
+    const realtimeWindowSeconds = useMemo(() => {
+        if (!hasRealtimeSeries || realtimeBucketSeconds <= 0) {
+            return rawRealtimeWindowSeconds
+        }
+
+        const renderedWindowSeconds = realtimeBucketSeconds * timeseriesPoints.length
+        if (rawRealtimeWindowSeconds <= 0) {
+            return renderedWindowSeconds
+        }
+
+        return Math.min(rawRealtimeWindowSeconds, renderedWindowSeconds)
+    }, [hasRealtimeSeries, rawRealtimeWindowSeconds, realtimeBucketSeconds, timeseriesPoints.length])
 
     const realtimeTotals = useMemo<RealtimeTotals>(() => {
         if (timeseriesPoints.length === 0) {
@@ -457,6 +479,7 @@ export function useMonitoringDashboardModel({
         }
 
         return statsPayload.routes
+            .filter((routeRow) => !isMonitoringRoute(routeRow.route))
             .slice(0, 8)
             .map((routeRow, index) => ({
                 id: index + 1,

--- a/frontend/src/services/monitoring.ts
+++ b/frontend/src/services/monitoring.ts
@@ -38,6 +38,19 @@ export type MonitoringStatsStreamOptions = {
 }
 
 const MONITORING_AUTH_REQUIRED_MESSAGE = 'Authentication credentials were not provided.'
+const MONITORING_API_URL = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000').replace(/\/+$/, '')
+const MONITORING_DEFAULT_ERROR_MESSAGE = 'Request failed. Please try again.'
+const READY_NON_OK_STATUS_CODES = [503]
+export const MONITORING_STREAM_UNEXPECTED_CLOSE_MESSAGE = 'Monitoring stream closed unexpectedly.'
+
+type MonitoringHttpError = Error & {
+    status?: number
+}
+
+type FetchMonitoringWithAuthAllowStatusesOptions = Readonly<{
+    accessToken?: string
+    allowedStatuses?: number[]
+}>
 
 export async function getMonitoringAuthToken(): Promise<string> {
     const accessToken = await getValidAccessToken()
@@ -55,6 +68,62 @@ async function fetchMonitoringWithAuth(endpoint: string, accessToken?: string): 
             Authorization: `Bearer ${token}`,
         },
     })
+}
+
+async function fetchMonitoringWithAuthAllowStatuses(
+    endpoint: string,
+    options: FetchMonitoringWithAuthAllowStatusesOptions = {},
+): Promise<unknown> {
+    const { accessToken, allowedStatuses = [] } = options
+    const token = accessToken ?? await getMonitoringAuthToken()
+    const normalizedEndpoint = endpoint.replace(/^\/+/, '')
+    const response = await fetch(`${MONITORING_API_URL}/${normalizedEndpoint}`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    })
+
+    const payload = await parseMonitoringJson(response)
+    if (response.ok || allowedStatuses.includes(response.status)) {
+        return payload
+    }
+
+    throw buildMonitoringHttpError(response.status, payload)
+}
+
+async function parseMonitoringJson(response: Response): Promise<unknown> {
+    try {
+        return await response.json()
+    } catch {
+        return {}
+    }
+}
+
+function buildMonitoringHttpError(status: number, payload: unknown): MonitoringHttpError {
+    const message = resolveMonitoringErrorMessage(payload)
+    const error = new Error(message) as MonitoringHttpError
+    error.status = status
+    return error
+}
+
+function resolveMonitoringErrorMessage(payload: unknown): string {
+    if (!isMonitoringRecord(payload)) {
+        return MONITORING_DEFAULT_ERROR_MESSAGE
+    }
+    const message = payload.message
+    if (typeof message === 'string' && message.trim()) {
+        return message
+    }
+    const detail = payload.detail
+    if (typeof detail === 'string' && detail.trim()) {
+        return detail
+    }
+    return MONITORING_DEFAULT_ERROR_MESSAGE
+}
+
+function isMonitoringRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null
 }
 
 function parseMonitoringSseEventBlock(rawEvent: string): string | null {
@@ -175,7 +244,7 @@ function buildMonitoringStreamUrl({
     const normalizedMaxEvents = getValidatedPositiveInteger(maxEvents)
     const maxEventsQuery = normalizedMaxEvents === undefined ? '' : `&max_events=${normalizedMaxEvents}`
 
-    return `monitoring/stream/?interval_seconds=${interval}${maxEventsQuery}`
+    return `${MONITORING_API_URL}/monitoring/stream/?interval_seconds=${interval}${maxEventsQuery}`
 }
 
 function buildMonitoringStreamInterval(intervalSeconds?: number): number {
@@ -212,7 +281,6 @@ async function fetchMonitoringStreamResponse({
         method: 'GET',
         headers: {
             Authorization: `Bearer ${safeAccessToken}`,
-            Accept: 'text/event-stream',
         },
         signal: controller.signal,
     })
@@ -294,7 +362,7 @@ function reportUnexpectedStreamClosure({
         return
     }
 
-    onError?.(new Error('Monitoring stream closed unexpectedly.'))
+    onError?.(new Error(MONITORING_STREAM_UNEXPECTED_CLOSE_MESSAGE))
 }
 
 function onStreamParseError({
@@ -341,9 +409,22 @@ export async function getMonitoringAccess(accessToken?: string): Promise<Monitor
 }
 
 export async function getMonitoringReady(accessToken?: string): Promise<MonitoringReadyPayload> {
-    return mapMonitoringReadyResponse(
-        await fetchMonitoringWithAuth('monitoring/ready/', accessToken)
-    )
+    try {
+        return mapMonitoringReadyResponse(
+            await fetchMonitoringWithAuth('monitoring/ready/', accessToken)
+        )
+    } catch (error) {
+        if ((error as MonitoringHttpError)?.status !== 503) {
+            throw error
+        }
+
+        return mapMonitoringReadyResponse(
+            await fetchMonitoringWithAuthAllowStatuses('monitoring/ready/', {
+                accessToken,
+                allowedStatuses: READY_NON_OK_STATUS_CODES,
+            })
+        )
+    }
 }
 
 export async function getMonitoringStats(accessToken?: string): Promise<MonitoringStatsPayload> {

--- a/frontend/tests/app/monitoring/MonitoringDashboardSections.test.tsx
+++ b/frontend/tests/app/monitoring/MonitoringDashboardSections.test.tsx
@@ -87,7 +87,7 @@ describe('MonitoringDashboardSections', () => {
         )
 
         fireEvent.click(screen.getByRole('button', { name: 'Refresh Monitoring' }))
-        expect(screen.getByText('Live')).toBeInTheDocument()
+        expect(screen.queryByText('Live')).not.toBeInTheDocument()
         expect(onRefresh).toHaveBeenCalledTimes(1)
     })
 
@@ -298,6 +298,7 @@ describe('MonitoringDashboardSections', () => {
         )
 
         expect(screen.getByText('Peak latency in last 10s:')).toBeInTheDocument()
+        expect(screen.getByText('Y-axis: Avg latency (ms). Max requests in series: 3')).toBeInTheDocument()
         expect(screen.getByText(/Latest bucket\s*10:00:00:\s*avg latency/)).toBeInTheDocument()
     })
 
@@ -428,6 +429,33 @@ describe('MonitoringDashboardSections', () => {
         expect(screen.getByText('Readiness data is available only for monitoring-enabled accounts.')).toBeInTheDocument()
     })
 
+    it('excludes monitoring routes from top routes rendering', () => {
+        render(
+            <MonitoringRoutesAndReadinessSection
+                statsPayload={{
+                    ...baseStatsPayload,
+                    routes: [
+                        {
+                            route: '/monitoring/stats/',
+                            method: 'GET',
+                            total_requests: 99,
+                            total_errors: 0,
+                            error_rate: 0,
+                            avg_latency_ms: 11,
+                            max_latency_ms: 15,
+                        },
+                        ...baseStatsPayload.routes,
+                    ],
+                }}
+                maxRouteRequests={60}
+                readyPayload={null}
+            />
+        )
+
+        expect(screen.queryByText('/monitoring/stats/')).not.toBeInTheDocument()
+        expect(screen.getByText('/history/')).toBeInTheDocument()
+    })
+
     it('renders readiness checks with optional check messages', () => {
         render(
             <MonitoringRoutesAndReadinessSection
@@ -438,7 +466,29 @@ describe('MonitoringDashboardSections', () => {
         )
 
         expect(screen.getByText(/^Timestamp:/)).toBeInTheDocument()
+        expect(screen.getByText('Database')).toBeInTheDocument()
+        expect(screen.getAllByText('OK').length).toBeGreaterThan(0)
         expect(screen.getByText('latency 5 ms - healthy')).toBeInTheDocument()
+    })
+
+    it('maps configured readiness check names to friendly labels', () => {
+        render(
+            <MonitoringRoutesAndReadinessSection
+                statsPayload={baseStatsPayload}
+                maxRouteRequests={60}
+                readyPayload={{
+                    status: 'ok',
+                    timestamp: '2026-04-24T10:00:05Z',
+                    checks: [
+                        { name: 'storage', status: 'ok', latency_ms: 4, is_critical: true },
+                        { name: 'openai_config', status: 'ok', latency_ms: 6, is_critical: true },
+                    ],
+                }}
+            />
+        )
+
+        expect(screen.getByText('Storage')).toBeInTheDocument()
+        expect(screen.getByText('LLM Config')).toBeInTheDocument()
     })
 
     it('renders readiness checks when message is omitted', () => {

--- a/frontend/tests/app/monitoring/components/primitives/MonitoringPrimitives.test.tsx
+++ b/frontend/tests/app/monitoring/components/primitives/MonitoringPrimitives.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+    GaugeMeter,
+    MetricCard,
+    StatusBadge,
+} from '../../../../../src/app/monitoring/components/primitives/MonitoringPrimitives'
+
+describe('MonitoringPrimitives', () => {
+    it('renders status badge with fallback label when label prop is omitted', () => {
+        render(<StatusBadge status="ok" />)
+        expect(screen.getByText('ok')).toBeInTheDocument()
+    })
+
+    it('renders metric card without subtitle', () => {
+        render(
+            <MetricCard title="Requests" value="12" />
+        )
+        expect(screen.getByText('Requests')).toBeInTheDocument()
+        expect(screen.queryByText(/^subtitle/i)).not.toBeInTheDocument()
+    })
+
+    it('renders gauge meter with aria label and caption', () => {
+        render(
+            <GaugeMeter
+                ariaLabel="Error rate meter"
+                label="Error Rate Meter"
+                valueText="5.00%"
+                caption="Window 60s"
+                progressLength={12.56}
+                strokeColor="#b91c1c"
+                valueClassName="text-red-700"
+            />
+        )
+        expect(screen.getByLabelText('Error rate meter')).toBeInTheDocument()
+        expect(screen.getByText('Window 60s')).toBeInTheDocument()
+    })
+})
+

--- a/frontend/tests/app/monitoring/monitoringUi.test.ts
+++ b/frontend/tests/app/monitoring/monitoringUi.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
     clamp,
     formatPercent,
+    formatReadinessCheckName,
+    formatStatusLabel,
     formatTimeLabel,
     formatTimestamp,
     resolveAccessMessage,
@@ -9,34 +11,39 @@ import {
 } from '../../../src/app/monitoring/monitoringUi'
 
 describe('monitoringUi helpers', () => {
-    it('returns original value for invalid timestamp strings', () => {
-        expect(formatTimestamp('invalid-date')).toBe('invalid-date')
+    it('returns raw value for invalid timestamp and time label input', () => {
+        expect(formatTimestamp('invalid-timestamp')).toBe('invalid-timestamp')
         expect(formatTimeLabel('invalid-time')).toBe('invalid-time')
     })
 
-    it('formats percentages and falls back for non-finite values', () => {
-        expect(formatPercent(0.125)).toBe('12.50%')
-        expect(formatPercent(Number.NaN)).toBe('0.00%')
+    it('formats finite and non-finite percentages', () => {
+        expect(formatPercent(0.1234)).toBe('12.34%')
         expect(formatPercent(Number.POSITIVE_INFINITY)).toBe('0.00%')
     })
 
-    it('maps status badges to expected classes', () => {
+    it('maps status badge classes including degraded branch', () => {
         expect(statusBadgeClass('ok')).toContain('text-blue-700')
-        expect(statusBadgeClass('degraded')).toContain('text-red-700')
-        expect(statusBadgeClass('down')).toContain('border-red-400')
-        expect(statusBadgeClass('exception')).toContain('border-red-400')
+        expect(statusBadgeClass('degraded')).toContain('border-red-300')
         expect(statusBadgeClass('error')).toContain('border-red-400')
-        expect(statusBadgeClass('custom')).toContain('text-gray-700')
+        expect(statusBadgeClass('unknown')).toContain('border-gray-300')
     })
 
-    it('resolves access messages with fallback', () => {
+    it('normalizes status labels and readiness check names', () => {
+        expect(formatStatusLabel('ok')).toBe('OK')
+        expect(formatStatusLabel('error')).toBe('Error')
+        expect(formatStatusLabel('warning')).toBe('warning')
+
+        expect(formatReadinessCheckName('database')).toBe('Database')
+        expect(formatReadinessCheckName(' storage ')).toBe('Storage')
+        expect(formatReadinessCheckName('openai_config')).toBe('LLM Config')
+        expect(formatReadinessCheckName('queue')).toBe('queue')
+    })
+
+    it('resolves known and unknown access reasons and clamps numbers', () => {
         expect(resolveAccessMessage('ok')).toBe('Monitoring access granted.')
         expect(resolveAccessMessage('custom_reason')).toBe('Access status: custom_reason')
-    })
-
-    it('clamps values into min/max boundaries', () => {
-        expect(clamp(10, 0, 5)).toBe(5)
-        expect(clamp(-1, 0, 5)).toBe(0)
-        expect(clamp(3, 0, 5)).toBe(3)
+        expect(clamp(15, 0, 10)).toBe(10)
+        expect(clamp(-2, 0, 10)).toBe(0)
     })
 })
+

--- a/frontend/tests/hooks/useMonitoringDashboardModel.test.ts
+++ b/frontend/tests/hooks/useMonitoringDashboardModel.test.ts
@@ -309,6 +309,51 @@ describe('useMonitoringDashboardModel', () => {
         ])
     })
 
+    it('limits realtime latency series to the latest six buckets', async () => {
+        const service = createMonitoringService({
+            getMonitoringStats: vi.fn().mockResolvedValue({
+                status: 'ok',
+                generated_at: '2026-04-24T10:00:02Z',
+                totals: { requests: 36, errors: 0, error_rate: 0 },
+                routes: [],
+                events: {},
+                timeseries: {
+                    window_seconds: 300,
+                    bucket_seconds: 10,
+                    points: [
+                        { timestamp: '2026-04-24T10:00:00Z', requests: 1, errors: 0, error_rate: 0, avg_latency_ms: 10 },
+                        { timestamp: '2026-04-24T10:00:10Z', requests: 2, errors: 0, error_rate: 0, avg_latency_ms: 20 },
+                        { timestamp: '2026-04-24T10:00:20Z', requests: 3, errors: 0, error_rate: 0, avg_latency_ms: 30 },
+                        { timestamp: '2026-04-24T10:00:30Z', requests: 4, errors: 0, error_rate: 0, avg_latency_ms: 40 },
+                        { timestamp: '2026-04-24T10:00:40Z', requests: 5, errors: 0, error_rate: 0, avg_latency_ms: 50 },
+                        { timestamp: '2026-04-24T10:00:50Z', requests: 6, errors: 0, error_rate: 0, avg_latency_ms: 60 },
+                        { timestamp: '2026-04-24T10:01:00Z', requests: 7, errors: 0, error_rate: 0, avg_latency_ms: 70 },
+                        { timestamp: '2026-04-24T10:01:10Z', requests: 8, errors: 0, error_rate: 0, avg_latency_ms: 80 },
+                    ],
+                },
+            }),
+        })
+
+        const { result } = renderHook(() =>
+            useMonitoringDashboardModel({
+                monitoringService: service,
+                autoRefreshIntervalMs: 60000,
+            })
+        )
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false)
+        })
+
+        expect(result.current.latencySeries.map((item) => item.value)).toEqual([30, 40, 50, 60, 70, 80])
+        expect(result.current.realtimeTotals).toEqual({
+            requests: 33,
+            errors: 0,
+            errorRate: 0,
+        })
+        expect(result.current.realtimeWindowSeconds).toBe(60)
+    })
+
     it('tracks retry backoff state and clears it after successful retry', async () => {
         vi.useFakeTimers()
         vi.setSystemTime(new Date('2026-04-24T10:00:00Z'))

--- a/frontend/tests/hooks/useMonitoringDashboardModel.test.ts
+++ b/frontend/tests/hooks/useMonitoringDashboardModel.test.ts
@@ -354,6 +354,39 @@ describe('useMonitoringDashboardModel', () => {
         expect(result.current.realtimeWindowSeconds).toBe(60)
     })
 
+    it('derives realtime window from rendered buckets when source window is zero', async () => {
+        const service = createMonitoringService({
+            getMonitoringStats: vi.fn().mockResolvedValue({
+                status: 'ok',
+                generated_at: '2026-04-24T10:00:02Z',
+                totals: { requests: 3, errors: 0, error_rate: 0 },
+                routes: [],
+                events: {},
+                timeseries: {
+                    window_seconds: 0,
+                    bucket_seconds: 10,
+                    points: [
+                        { timestamp: '2026-04-24T10:00:00Z', requests: 1, errors: 0, error_rate: 0, avg_latency_ms: 10 },
+                        { timestamp: '2026-04-24T10:00:10Z', requests: 2, errors: 0, error_rate: 0, avg_latency_ms: 20 },
+                    ],
+                },
+            }),
+        })
+
+        const { result } = renderHook(() =>
+            useMonitoringDashboardModel({
+                monitoringService: service,
+                autoRefreshIntervalMs: 60000,
+            })
+        )
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false)
+        })
+
+        expect(result.current.realtimeWindowSeconds).toBe(20)
+    })
+
     it('tracks retry backoff state and clears it after successful retry', async () => {
         vi.useFakeTimers()
         vi.setSystemTime(new Date('2026-04-24T10:00:00Z'))
@@ -1139,5 +1172,35 @@ describe('useMonitoringDashboardModel', () => {
                 (service.getMonitoringStatsStream as ReturnType<typeof vi.fn>).mock.calls.length
             ).toBe(2)
         })
+    })
+
+    it('suppresses error banner message when stream closes unexpectedly', async () => {
+        const streamClose = vi.fn()
+        let capturedError: ((error: Error) => void) | undefined
+        const service = createMonitoringService({
+            getMonitoringStatsStream: vi.fn().mockImplementation(async ({ onError }) => {
+                capturedError = onError
+                return { close: streamClose }
+            }),
+        })
+
+        const { result } = renderHook(() =>
+            useMonitoringDashboardModel({
+                monitoringService: service,
+                autoRefreshIntervalMs: 60000,
+            })
+        )
+
+        await waitFor(() => {
+            expect(service.getMonitoringStatsStream).toHaveBeenCalledTimes(1)
+        })
+
+        act(() => {
+            capturedError?.(new Error('Monitoring stream closed unexpectedly.'))
+        })
+
+        expect(result.current.errorMessage).toBeNull()
+        expect(streamClose).toHaveBeenCalledTimes(1)
+        expect(result.current.consecutiveFailures).toBe(1)
     })
 })

--- a/frontend/tests/services/monitoring.test.ts
+++ b/frontend/tests/services/monitoring.test.ts
@@ -161,6 +161,107 @@ describe('monitoring service', () => {
         })
     })
 
+    it('falls back to default message when readiness fallback returns non-JSON error body', async () => {
+        const { fetchAPI } = await import('@/lib/api')
+        const { getValidAccessToken } = await import('@/lib/auth')
+        const { getMonitoringReady } = await import('@/services/monitoring')
+
+        vi.mocked(getValidAccessToken).mockResolvedValue('token-ready-non-json')
+        const readinessUnavailableError = new Error('Service Unavailable') as Error & { status?: number }
+        readinessUnavailableError.status = 503
+        vi.mocked(fetchAPI).mockRejectedValueOnce(readinessUnavailableError)
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response('not-json-body', {
+                    status: 500,
+                    headers: { 'Content-Type': 'text/plain' },
+                })
+            )
+        )
+
+        await expect(getMonitoringReady()).rejects.toThrow('Request failed. Please try again.')
+    })
+
+    it('uses detail field from readiness fallback error payload', async () => {
+        const { fetchAPI } = await import('@/lib/api')
+        const { getValidAccessToken } = await import('@/lib/auth')
+        const { getMonitoringReady } = await import('@/services/monitoring')
+
+        vi.mocked(getValidAccessToken).mockResolvedValue('token-ready-detail')
+        const readinessUnavailableError = new Error('Service Unavailable') as Error & { status?: number }
+        readinessUnavailableError.status = 503
+        vi.mocked(fetchAPI).mockRejectedValueOnce(readinessUnavailableError)
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({ detail: 'Readiness backend unavailable.' }),
+                    {
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json' },
+                    }
+                )
+            )
+        )
+
+        await expect(getMonitoringReady()).rejects.toThrow('Readiness backend unavailable.')
+    })
+
+    it('uses message field from readiness fallback error payload', async () => {
+        const { fetchAPI } = await import('@/lib/api')
+        const { getValidAccessToken } = await import('@/lib/auth')
+        const { getMonitoringReady } = await import('@/services/monitoring')
+
+        vi.mocked(getValidAccessToken).mockResolvedValue('token-ready-message')
+        const readinessUnavailableError = new Error('Service Unavailable') as Error & { status?: number }
+        readinessUnavailableError.status = 503
+        vi.mocked(fetchAPI).mockRejectedValueOnce(readinessUnavailableError)
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({ message: 'Readiness check failed.' }),
+                    {
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json' },
+                    }
+                )
+            )
+        )
+
+        await expect(getMonitoringReady()).rejects.toThrow('Readiness check failed.')
+    })
+
+    it('uses default message when readiness fallback error payload is non-object JSON', async () => {
+        const { fetchAPI } = await import('@/lib/api')
+        const { getValidAccessToken } = await import('@/lib/auth')
+        const { getMonitoringReady } = await import('@/services/monitoring')
+
+        vi.mocked(getValidAccessToken).mockResolvedValue('token-ready-scalar')
+        const readinessUnavailableError = new Error('Service Unavailable') as Error & { status?: number }
+        readinessUnavailableError.status = 503
+        vi.mocked(fetchAPI).mockRejectedValueOnce(readinessUnavailableError)
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(
+                    '123',
+                    {
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json' },
+                    }
+                )
+            )
+        )
+
+        await expect(getMonitoringReady()).rejects.toThrow('Request failed. Please try again.')
+    })
+
     it('calls stats endpoint with bearer token', async () => {
         const { fetchAPI } = await import('@/lib/api')
         const { getValidAccessToken } = await import('@/lib/auth')

--- a/frontend/tests/services/monitoring.test.ts
+++ b/frontend/tests/services/monitoring.test.ts
@@ -106,6 +106,61 @@ describe('monitoring service', () => {
         expect(fetchAPI).not.toHaveBeenCalled()
     })
 
+    it('maps readiness payload when endpoint responds with 503 degraded status', async () => {
+        const { fetchAPI } = await import('@/lib/api')
+        const { getValidAccessToken } = await import('@/lib/auth')
+        const { getMonitoringReady } = await import('@/services/monitoring')
+
+        vi.mocked(getValidAccessToken).mockResolvedValue('token-ready-503')
+        const readinessUnavailableError = new Error('Service Unavailable') as Error & { status?: number }
+        readinessUnavailableError.status = 503
+        vi.mocked(fetchAPI).mockRejectedValueOnce(readinessUnavailableError)
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        status: 'degraded',
+                        timestamp: '2026-04-26T09:50:00Z',
+                        checks: [
+                            { name: 'openai_config', status: 'error', latency_ms: 1, is_critical: false },
+                        ],
+                    }),
+                    {
+                        status: 503,
+                        headers: { 'Content-Type': 'application/json' },
+                    }
+                )
+            )
+        )
+
+        const result = await getMonitoringReady()
+
+        expect(fetchAPI).toHaveBeenCalledWith('monitoring/ready/', {
+            method: 'GET',
+            headers: {
+                Authorization: 'Bearer token-ready-503',
+            },
+        })
+        expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+            'http://localhost:8000/monitoring/ready/',
+            expect.objectContaining({
+                method: 'GET',
+                headers: {
+                    Authorization: 'Bearer token-ready-503',
+                },
+            })
+        )
+        expect(result).toEqual({
+            status: 'degraded',
+            timestamp: '2026-04-26T09:50:00Z',
+            checks: [
+                { name: 'openai_config', status: 'error', latency_ms: 1, is_critical: false },
+            ],
+        })
+    })
+
     it('calls stats endpoint with bearer token', async () => {
         const { fetchAPI } = await import('@/lib/api')
         const { getValidAccessToken } = await import('@/lib/auth')
@@ -464,7 +519,7 @@ describe('monitoring service', () => {
 
         await waitFor(() => expect(onPayload).toHaveBeenCalledTimes(1))
         const streamUrl = streamURLs.at(0)
-        expect(streamUrl).toBe('monitoring/stream/?interval_seconds=1')
+        expect(streamUrl).toBe('http://localhost:8000/monitoring/stream/?interval_seconds=1')
         expect(onError).toHaveBeenCalledWith(
             expect.objectContaining({ message: 'Monitoring stream closed unexpectedly.' })
         )
@@ -498,7 +553,7 @@ describe('monitoring service', () => {
 
         await waitFor(() => expect(onPayload).toHaveBeenCalledTimes(1))
         const streamUrl = streamURLs.at(0)
-        expect(streamUrl).toBe('monitoring/stream/?interval_seconds=1')
+        expect(streamUrl).toBe('http://localhost:8000/monitoring/stream/?interval_seconds=1')
         expect(streamURLs.at(0)).not.toContain('max_events=')
         expect(onError).toHaveBeenCalledWith(
             expect.objectContaining({ message: 'Monitoring stream closed unexpectedly.' })

--- a/frontend/tests/unit/pages/MonitoringRoutePage.test.tsx
+++ b/frontend/tests/unit/pages/MonitoringRoutePage.test.tsx
@@ -1,21 +1,21 @@
 import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import Page from '../../../src/app/monitoring/page'
 
 vi.mock('../../../src/components/AuthGuard', () => ({
-    default: ({ children }: { children: React.ReactNode }) => (
+    default: ({ children }: { children: ReactNode }) => (
         <div data-testid="auth-guard">{children}</div>
     ),
 }))
 
 vi.mock('../../../src/app/monitoring/MonitoringPage', () => ({
-    default: () => <div data-testid="monitoring-page">Monitoring Page</div>,
+    default: () => <div data-testid="monitoring-page" />,
 }))
 
-describe('monitoring route page', () => {
+describe('Monitoring route page wrapper', () => {
     it('wraps MonitoringPage with AuthGuard', () => {
         render(<Page />)
-
         expect(screen.getByTestId('auth-guard')).toBeInTheDocument()
         expect(screen.getByTestId('monitoring-page')).toBeInTheDocument()
     })


### PR DESCRIPTION
<!-- Use [**Conventional Commits**](https://www.conventionalcommits.org/en/v1.0.0/) format for PR titles:

```
<type>(<scope>): <description>
```

### **Common Types:**

* `feat`: New feature
* `fix`: Bug fix
* `docs`: Documentation changes
* `style`: Code style changes (formatting, no logic changes)
* `refactor`: Code refactoring
* `test`: Adding or updating tests
* `chore`: Maintenance tasks, dependency updates

### **Description Field:**

* Recommended to start a \<description\> with a verb (add, resolve, update, etc.)

### **Examples:**

* `feat(auth): add OAuth2 login integration`
* `fix(api): resolve null pointer exception in user service`
* `docs(readme): update installation instructions`
* `refactor(database): optimize query performance`
* `feat(BE): add vector DB connection`
* `fix(FE): login redirection` -->

## Summary


This pull request introduces several improvements and fixes to the backend monitoring, authentication, and frontend monitoring dashboard. The most significant changes include expanding error tracking to include all HTTP 4xx and 5xx responses, enhancing the monitoring middleware to skip self-monitoring routes, adding and improving tests for these behaviors, and refining the frontend monitoring UI for clarity and consistency.

**Backend Monitoring and Error Tracking:**

* Expanded error tracking in `RequestMetricRepository` to count all HTTP 4xx (client errors) as errors, not just 5xx (server errors), affecting error aggregation and real-time records. [[1]](diffhunk://#diff-7b3c462bb62043d371264e879a9b8cfcce3513b4b9ec28720af1a252a5979540L76-R76) [[2]](diffhunk://#diff-7b3c462bb62043d371264e879a9b8cfcce3513b4b9ec28720af1a252a5979540L541-R541) [[3]](diffhunk://#diff-7b3c462bb62043d371264e879a9b8cfcce3513b4b9ec28720af1a252a5979540L733-R733)
* Added tests to ensure that client errors (4xx) are correctly counted in error totals and timeseries in both in-memory and Redis-backed repositories. [[1]](diffhunk://#diff-72c3cc3b54b6d66865ee1a25edd8fb38a2e0798cf6f74f3f6fd263e6eb4f4586R217-R227) [[2]](diffhunk://#diff-72c3cc3b54b6d66865ee1a25edd8fb38a2e0798cf6f74f3f6fd263e6eb4f4586R1248-R1258)

**Monitoring Middleware Enhancements:**

* Updated the monitoring middleware to skip recording metrics for requests to monitoring endpoints (routes starting with `/monitoring/`), preventing self-monitoring from polluting metrics. [[1]](diffhunk://#diff-3ece929b40c6d3f014c11707676ce0c9eba812062d11460a261e60e1bbac1ec9R11) [[2]](diffhunk://#diff-3ece929b40c6d3f014c11707676ce0c9eba812062d11460a261e60e1bbac1ec9R34-R35) [[3]](diffhunk://#diff-3ece929b40c6d3f014c11707676ce0c9eba812062d11460a261e60e1bbac1ec9R58-R62)
* Added tests to verify that monitoring routes are properly excluded from metric recording.
* Registered the monitoring middleware in Django settings to ensure it's active.

**Authentication and Metrics:**

* Instrumented the login endpoint with a decorator to record authentication metric events, and added a test to verify that successful logins are tracked. [[1]](diffhunk://#diff-479cc2a3eccc4f1def06eb939aca48314070400dba0778b3b94e95edbc3d67e1R24) [[2]](diffhunk://#diff-479cc2a3eccc4f1def06eb939aca48314070400dba0778b3b94e95edbc3d67e1R44) [[3]](diffhunk://#diff-99e3d077bde7165f89c93fcafe9e583cfef570448c05da2f0fae6c21ef40fc2dR41-R72)

**Frontend Monitoring Dashboard Improvements:**

* Improved display of status and readiness labels using formatting helpers, clarified access labels, and removed unnecessary "Live" badge for clarity. [[1]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73L8-R14) [[2]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73R25-R31) [[3]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73L46-R59) [[4]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73L59-R72) [[5]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73L114-R130) [[6]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73L198-R207)
* Added Y-axis labeling and max request count to the latency chart for better interpretability. [[1]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73R243-R247) [[2]](diffhunk://#diff-d8cffbac02884f32a09c7e74e1c23c81c697cb921325d9535d8e1f4e45867a73R264-R266)

**Other Fixes and Enhancements:**

* Set a default `User-Agent` header for Discord webhook notifications and added a test to verify this. [[1]](diffhunk://#diff-d614a207018a07af234ed62e6d251ed4916d3733b9d25dc4e00eb2d7cb52ea21R13) [[2]](diffhunk://#diff-d614a207018a07af234ed62e6d251ed4916d3733b9d25dc4e00eb2d7cb52ea21L24-R28) [[3]](diffhunk://#diff-0e3450fcc02923519feddcb93908cd3177c4c063bcf499bedc5908507d34438cR133-R136)
* Added a test to ensure that non-positive values for the max routes per snapshot setting are ignored.
* Minor frontend UI cleanup for error message display.

## How to Test

<!--- Steps to manually test or verify functionality-->

1. Clone and run both BE and FE
2. Try to remove your OpenAI API key
3. See that the Discord Webhook will be fire
4. Now, put all correct value into the .env
5. See that the metrics of readiness will be 3/3

## Related Issues

#250 

## Author Checklist

- [x] Code follows team coding standards and style guide
- [x] Self-reviewed the code changes
- [x] Added/updated tests for new functionality
- [x] All tests pass locally
- [x] Code is properly documented
- [x] Synced with latest `main` branch
- [x] PR title follows conventional commit format
- [x] Meaningful commit messages used

## Additional Notes

<!-- Any additional context, screenshots, or information reviewers should know -->

## Type of task

<!--- Please checklist options that are relevant -->

- [ ] Data Processing (for tasks involving data handling or manipulation)
- [ ] Model Training (for tasks involving model training)
- [ ] API Development (for developing or serving model via API)
- [ ] UI Development (for developing or improving user interface)
- [ ] Testing (for writing or updating tests)
- [ ] Debugging (for fixing errors or investigating issues)
- [ ] Refactor (for code improvements without changing functionality)
- [ ] Performance Improvement / Optimization (for optimizations related to speed or efficiency)
- [ ] Security (for tasks related to security updates or patches)
- [x] Documentation (for updating or improving documentation)
- [x] Monitoring (for adding or updating monitoring capabilities)
- [ ] All

## Reviewer(s)

<!--- Please add the names or GitHub usernames of the reviewers -->

- [ ] @zufarra 