### PR TITLE
feat(session) Implement resume session endpoint

### DIFF
--- a/backend/api/tests/test_views.py
+++ b/backend/api/tests/test_views.py
@@ -3532,3 +3532,122 @@ class SessionEndpointTests(TestCase):
             },
         )
         mock_open_file.assert_called_once()
+
+    @patch("api.views.build_resume_context_for_user")
+    def test_session_resume_requires_authentication(self, mock_build_resume_context):
+        request = self.factory.get(f"/sessions/{self.session_id}/resume/")
+
+        response = views.session_resume(request, self.session_id)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        mock_build_resume_context.assert_not_called()
+
+    @patch("api.views.build_resume_context_for_user")
+    def test_session_resume_requires_verified_user(self, mock_build_resume_context):
+        request = self.factory.get(f"/sessions/{self.session_id}/resume/")
+        force_authenticate(request, user=self.unverified_user)
+
+        response = views.session_resume(request, self.session_id)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_build_resume_context.assert_not_called()
+
+    @patch("api.views.build_resume_context_for_user")
+    def test_session_resume_returns_not_found_when_session_missing(
+        self,
+        mock_build_resume_context,
+    ):
+        mock_build_resume_context.return_value = None
+        request = self.factory.get(f"/sessions/{self.session_id}/resume/")
+        force_authenticate(request, user=self.user)
+
+        response = views.session_resume(request, self.session_id)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data, {"detail": "Not found."})
+        mock_build_resume_context.assert_called_once_with(self.user, self.session_id)
+
+    @patch("api.views.build_resume_context_for_user")
+    def test_session_resume_returns_serialized_history_when_found(
+        self,
+        mock_build_resume_context,
+    ):
+        created_at = timezone.now()
+        mock_build_resume_context.return_value = SimpleNamespace(
+            id=self.session_id,
+            title="Resume Session",
+            created_at=created_at,
+            updated_at=created_at,
+            last_message_at=created_at,
+            last_output_at=created_at,
+            history=[
+                SimpleNamespace(
+                    type="message",
+                    id=uuid.uuid4(),
+                    role="assistant",
+                    content="Resume me",
+                    thinking_log="Reasoned reply",
+                    created_at=created_at,
+                ),
+                SimpleNamespace(
+                    type="output",
+                    id=uuid.uuid4(),
+                    output_json={"document_info": {}, "summary": {}, "content_data": []},
+                    thinking_log="Mapped workbook structure",
+                    created_at=created_at,
+                ),
+            ],
+        )
+        request = self.factory.get(f"/sessions/{self.session_id}/resume/")
+        force_authenticate(request, user=self.user)
+
+        response = views.session_resume(request, self.session_id)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], str(self.session_id))
+        self.assertEqual(response.data["title"], "Resume Session")
+        self.assertEqual(len(response.data["history"]), 2)
+        self.assertEqual(response.data["history"][0]["type"], "message")
+        self.assertEqual(response.data["history"][0]["thinking_log"], "Reasoned reply")
+        self.assertEqual(response.data["history"][1]["type"], "output")
+        self.assertEqual(
+            response.data["history"][1]["thinking_log"],
+            "Mapped workbook structure",
+        )
+        mock_build_resume_context.assert_called_once_with(self.user, self.session_id)
+
+    @patch("api.views.build_resume_context_for_user")
+    def test_session_resume_supports_minimal_or_partial_history(
+        self,
+        mock_build_resume_context,
+    ):
+        created_at = timezone.now()
+        mock_build_resume_context.return_value = SimpleNamespace(
+            id=self.session_id,
+            title="Partial Session",
+            created_at=created_at,
+            updated_at=created_at,
+            last_message_at=None,
+            last_output_at=created_at,
+            history=[
+                SimpleNamespace(
+                    type="output",
+                    id=uuid.uuid4(),
+                    output_json={"document_info": {}, "summary": {}, "content_data": []},
+                    thinking_log="Only output context",
+                    created_at=created_at,
+                )
+            ],
+        )
+        request = self.factory.get(f"/sessions/{self.session_id}/resume/")
+        force_authenticate(request, user=self.user)
+
+        response = views.session_resume(request, self.session_id)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["history"]), 1)
+        self.assertEqual(response.data["history"][0]["type"], "output")
+        self.assertEqual(
+            response.data["history"][0]["thinking_log"],
+            "Only output context",
+        )

--- a/backend/api/tests/test_views.py
+++ b/backend/api/tests/test_views.py
@@ -1,4 +1,5 @@
 from PyPDF2 import PdfReader, PdfWriter
+import uuid
 from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation
 from django.utils._os import safe_join

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path("about/", views.about),
     path("members/", views.members),
     path("sessions/", views.session_list),
+    path("sessions/<uuid:session_id>/resume/", views.session_resume),
     path("sessions/<uuid:session_id>/", views.SessionResourceView.as_view()),
     path(
         "sessions/<uuid:session_id>/outputs/<uuid:output_id>/download/csv/",

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -27,9 +27,11 @@ from authentication.permissions import IsVerifiedUser
 from chat_sessions.serializers import (
     SessionDetailSerializer,
     SessionListItemSerializer,
+    SessionResumeSerializer,
     SessionTitleUpdateSerializer,
 )
 from chat_sessions.services import (
+    build_resume_context_for_user,
     delete_session,
     get_generated_output_for_session_user,
     get_default_session_detail_pagination,
@@ -1064,6 +1066,19 @@ def _build_session_detail_response(request, session_id):
         return Response({"detail": NOT_FOUND_DETAIL}, status=status.HTTP_404_NOT_FOUND)
 
     return Response(SessionDetailSerializer(session).data, status=status.HTTP_200_OK)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated, IsVerifiedUser])
+def session_resume(request, session_id):
+    resume_context = build_resume_context_for_user(request.user, session_id)
+    if resume_context is None:
+        return Response({"detail": NOT_FOUND_DETAIL}, status=status.HTTP_404_NOT_FOUND)
+
+    return Response(
+        SessionResumeSerializer(resume_context).data,
+        status=status.HTTP_200_OK,
+    )
 
 
 @api_view(["PATCH"])

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1067,7 +1067,7 @@ def _build_session_detail_response(request, session_id):
 
     return Response(SessionDetailSerializer(session).data, status=status.HTTP_200_OK)
 
-
+@require_GET
 @api_view(["GET"])
 @permission_classes([IsAuthenticated, IsVerifiedUser])
 def session_resume(request, session_id):

--- a/backend/chat_sessions/serializers.py
+++ b/backend/chat_sessions/serializers.py
@@ -16,6 +16,33 @@ class GeneratedOutputSerializer(serializers.Serializer):
     created_at = serializers.DateTimeField()
 
 
+class ResumeHistoryMessageSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    id = serializers.UUIDField()
+    role = serializers.CharField()
+    content = serializers.CharField()
+    thinking_log = serializers.CharField(allow_blank=True)
+    created_at = serializers.DateTimeField()
+
+
+class ResumeHistoryOutputSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    id = serializers.UUIDField()
+    output_json = serializers.JSONField()
+    thinking_log = serializers.CharField(allow_blank=True)
+    created_at = serializers.DateTimeField()
+
+
+class ResumeHistoryItemSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        item_type = getattr(instance, "type", None)
+        if item_type == "message":
+            return ResumeHistoryMessageSerializer(instance).data
+        if item_type == "output":
+            return ResumeHistoryOutputSerializer(instance).data
+        raise serializers.ValidationError("Unsupported resume history item type.")
+
+
 class PaginatedCollectionSerializer(serializers.Serializer):
     count = serializers.IntegerField(min_value=0)
     limit = serializers.IntegerField(min_value=1)
@@ -42,6 +69,10 @@ class SessionListItemSerializer(serializers.Serializer):
 class SessionDetailSerializer(SessionListItemSerializer):
     messages = PaginatedChatMessageCollectionSerializer()
     generated_outputs = PaginatedGeneratedOutputCollectionSerializer()
+
+
+class SessionResumeSerializer(SessionListItemSerializer):
+    history = ResumeHistoryItemSerializer(many=True)
 
 
 class SessionTitleUpdateSerializer(serializers.Serializer):

--- a/backend/chat_sessions/services.py
+++ b/backend/chat_sessions/services.py
@@ -112,6 +112,24 @@ def get_paginated_session_detail_for_user(
     )
 
 
+def build_resume_context_for_user(user, session_id):
+    session = get_session_for_user(user, session_id)
+    if session is None:
+        return None
+
+    history = _build_resume_history(session)
+
+    return SimpleNamespace(
+        id=session.id,
+        title=session.title,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        last_message_at=session.last_message_at,
+        last_output_at=session.last_output_at,
+        history=history,
+    )
+
+
 def get_default_session_detail_pagination():
     return dict(SESSION_DETAIL_PAGINATION_DEFAULTS)
 
@@ -142,6 +160,35 @@ def _build_paginated_collection(queryset, limit, offset):
         "offset": offset,
         "results": list(queryset[offset : offset + limit]),
     }
+
+
+def _build_resume_history(session):
+    message_items = [
+        SimpleNamespace(
+            type="message",
+            id=message.id,
+            role=message.role,
+            content=message.content,
+            thinking_log=message.thinking_log,
+            created_at=message.created_at,
+        )
+        for message in session.messages.order_by("created_at", "id")
+    ]
+    output_items = [
+        SimpleNamespace(
+            type="output",
+            id=output.id,
+            output_json=output.output_json,
+            thinking_log=output.thinking_log,
+            created_at=output.created_at,
+        )
+        for output in session.generated_outputs.order_by("created_at", "id")
+    ]
+
+    return sorted(
+        [*message_items, *output_items],
+        key=lambda item: (item.created_at, str(item.id)),
+    )
 
 
 def update_session_title(session, title):

--- a/backend/chat_sessions/services.py
+++ b/backend/chat_sessions/services.py
@@ -1,6 +1,8 @@
+from heapq import merge
 from types import SimpleNamespace
 
 from django.conf import settings
+from django.db.models import Prefetch
 from django.utils import timezone
 
 from chat_sessions.models import ChatMessage, GeneratedOutput, Session
@@ -113,7 +115,20 @@ def get_paginated_session_detail_for_user(
 
 
 def build_resume_context_for_user(user, session_id):
-    session = get_session_for_user(user, session_id)
+    session = (
+        Session.objects.filter(owner=user, id=session_id)
+        .prefetch_related(
+            Prefetch(
+                "messages",
+                queryset=ChatMessage.objects.order_by("created_at", "id"),
+            ),
+            Prefetch(
+                "generated_outputs",
+                queryset=GeneratedOutput.objects.order_by("created_at", "id"),
+            ),
+        )
+        .first()
+    )
     if session is None:
         return None
 
@@ -163,7 +178,7 @@ def _build_paginated_collection(queryset, limit, offset):
 
 
 def _build_resume_history(session):
-    message_items = [
+    message_items = (
         SimpleNamespace(
             type="message",
             id=message.id,
@@ -172,9 +187,9 @@ def _build_resume_history(session):
             thinking_log=message.thinking_log,
             created_at=message.created_at,
         )
-        for message in session.messages.order_by("created_at", "id")
-    ]
-    output_items = [
+        for message in session.messages.all()
+    )
+    output_items = (
         SimpleNamespace(
             type="output",
             id=output.id,
@@ -182,12 +197,15 @@ def _build_resume_history(session):
             thinking_log=output.thinking_log,
             created_at=output.created_at,
         )
-        for output in session.generated_outputs.order_by("created_at", "id")
-    ]
+        for output in session.generated_outputs.all()
+    )
 
-    return sorted(
-        [*message_items, *output_items],
-        key=lambda item: (item.created_at, str(item.id)),
+    return list(
+        merge(
+            message_items,
+            output_items,
+            key=lambda item: (item.created_at, str(item.id)),
+        )
     )
 
 

--- a/backend/chat_sessions/tests/test_serializers.py
+++ b/backend/chat_sessions/tests/test_serializers.py
@@ -8,6 +8,7 @@ from chat_sessions.serializers import (
     PaginatedChatMessageCollectionSerializer,
     PaginatedCollectionSerializer,
     PaginatedGeneratedOutputCollectionSerializer,
+    SessionResumeSerializer,
     SessionDetailSerializer,
     SessionListItemSerializer,
     SessionTitleUpdateSerializer,
@@ -146,6 +147,59 @@ class ChatSessionSerializerTest(SimpleTestCase):
             serializer.data["generated_outputs"],
             {"count": 0, "limit": 10, "offset": 0, "results": []},
         )
+
+    def test_session_resume_serializer_includes_chat_history_and_thinking_logs(self):
+        session = self._session_stub()
+        session.history = [
+            SimpleNamespace(
+                type="message",
+                id="message-1",
+                role="assistant",
+                content="Here is the summary.",
+                thinking_log="Grouped expense rows before answering.",
+                created_at=datetime(2026, 4, 21, 10, 3, tzinfo=timezone.utc),
+            ),
+            SimpleNamespace(
+                type="output",
+                id="output-1",
+                output_json={
+                    "document_info": {"source_type": "Excel", "filename": "example.xlsx"},
+                    "summary": {"total_sheets": 1, "total_rows": 2, "total_columns": 5},
+                    "content_data": [],
+                },
+                thinking_log="Normalized columns and preserved totals.",
+                created_at=datetime(2026, 4, 21, 10, 4, tzinfo=timezone.utc),
+            ),
+        ]
+
+        serializer = SessionResumeSerializer(session)
+
+        self.assertEqual(serializer.data["id"], "session-1")
+        self.assertEqual(len(serializer.data["history"]), 2)
+        self.assertEqual(serializer.data["history"][0]["type"], "message")
+        self.assertEqual(serializer.data["history"][0]["role"], "assistant")
+        self.assertEqual(
+            serializer.data["history"][0]["thinking_log"],
+            "Grouped expense rows before answering.",
+        )
+        self.assertEqual(serializer.data["history"][1]["type"], "output")
+        self.assertEqual(
+            serializer.data["history"][1]["output_json"]["document_info"]["filename"],
+            "example.xlsx",
+        )
+        self.assertEqual(
+            serializer.data["history"][1]["thinking_log"],
+            "Normalized columns and preserved totals.",
+        )
+
+    def test_session_resume_serializer_supports_empty_history(self):
+        session = self._session_stub()
+        session.history = []
+
+        serializer = SessionResumeSerializer(session)
+
+        self.assertEqual(serializer.data["id"], "session-1")
+        self.assertEqual(serializer.data["history"], [])
 
     def test_paginated_collection_serializer_defines_shared_pagination_fields(self):
         serializer = PaginatedCollectionSerializer(data={"count": 1, "limit": 10, "offset": 0})

--- a/backend/chat_sessions/tests/test_serializers.py
+++ b/backend/chat_sessions/tests/test_serializers.py
@@ -8,6 +8,7 @@ from chat_sessions.serializers import (
     PaginatedChatMessageCollectionSerializer,
     PaginatedCollectionSerializer,
     PaginatedGeneratedOutputCollectionSerializer,
+    ResumeHistoryItemSerializer,
     SessionResumeSerializer,
     SessionDetailSerializer,
     SessionListItemSerializer,
@@ -200,6 +201,18 @@ class ChatSessionSerializerTest(SimpleTestCase):
 
         self.assertEqual(serializer.data["id"], "session-1")
         self.assertEqual(serializer.data["history"], [])
+
+    def test_resume_history_item_serializer_rejects_unsupported_item_type(self):
+        serializer = ResumeHistoryItemSerializer()
+
+        with self.assertRaises(serializers.ValidationError):
+            serializer.to_representation(
+                SimpleNamespace(
+                    type="metadata",
+                    id="meta-1",
+                    created_at=datetime(2026, 4, 21, 10, 4, tzinfo=timezone.utc),
+                )
+            )
 
     def test_paginated_collection_serializer_defines_shared_pagination_fields(self):
         serializer = PaginatedCollectionSerializer(data={"count": 1, "limit": 10, "offset": 0})

--- a/backend/chat_sessions/tests/test_services.py
+++ b/backend/chat_sessions/tests/test_services.py
@@ -388,6 +388,39 @@ class ChatSessionServiceTest(TestCase):
             "Only thinking log metadata is available.",
         )
 
+    def test_build_resume_context_for_user_prefetches_history_without_extra_queries_after_load(self):
+        session = Session.objects.create(
+            owner=self.owner,
+            title="Prefetched Session",
+        )
+        message_created_at = timezone.now() + timezone.timedelta(minutes=1)
+        output_created_at = timezone.now() + timezone.timedelta(minutes=2)
+        ChatMessage.objects.create(
+            session=session,
+            role=ChatMessage.ROLE_USER,
+            content="Halo",
+            created_at=message_created_at,
+        )
+        GeneratedOutput.objects.create(
+            session=session,
+            output_json={
+                "document_info": {"source_type": "Excel", "filename": "prefetched.xlsx"},
+                "summary": {"total_sheets": 1, "total_rows": 0, "total_columns": 0},
+                "content_data": [],
+            },
+            thinking_log="Only output context",
+            created_at=output_created_at,
+        )
+
+        with self.assertNumQueries(3):
+            result = build_resume_context_for_user(self.owner, session.id)
+
+        with self.assertNumQueries(0):
+            self.assertEqual(result.title, "Prefetched Session")
+            self.assertEqual(len(result.history), 2)
+            self.assertEqual(result.history[0].type, "message")
+            self.assertEqual(result.history[1].type, "output")
+
     def test_get_paginated_session_detail_for_user_rejects_invalid_limits(self):
         session = Session.objects.create(
             owner=self.owner,

--- a/backend/chat_sessions/tests/test_services.py
+++ b/backend/chat_sessions/tests/test_services.py
@@ -9,6 +9,7 @@ from chat_sessions.services import (
     append_assistant_message,
     append_user_message,
     build_history_with_summary,
+    build_resume_context_for_user,
     create_generated_output,
     create_session_for_user,
     delete_session,
@@ -296,6 +297,96 @@ class ChatSessionServiceTest(TestCase):
         result = get_paginated_session_detail_for_user(self.owner, session.id)
 
         self.assertIsNone(result)
+
+    def test_build_resume_context_for_user_returns_owned_session_history_in_chronological_order(self):
+        session = Session.objects.create(
+            owner=self.owner,
+            title="Owned Session",
+        )
+        user_message = ChatMessage.objects.create(
+            session=session,
+            role=ChatMessage.ROLE_USER,
+            content="Please continue this conversation.",
+            created_at=timezone.now() + timezone.timedelta(minutes=1),
+        )
+        assistant_message = ChatMessage.objects.create(
+            session=session,
+            role=ChatMessage.ROLE_ASSISTANT,
+            content="Here is the previous answer.",
+            thinking_log="Summarized totals before answering.",
+            created_at=timezone.now() + timezone.timedelta(minutes=2),
+        )
+        generated_output = GeneratedOutput.objects.create(
+            session=session,
+            output_json={
+                "document_info": {"source_type": "Excel", "filename": "resume.xlsx"},
+                "summary": {"total_sheets": 1, "total_rows": 1, "total_columns": 2},
+                "content_data": [],
+            },
+            thinking_log="Normalized columns and preserved totals.",
+            created_at=timezone.now() + timezone.timedelta(minutes=3),
+        )
+
+        result = build_resume_context_for_user(self.owner, session.id)
+
+        self.assertEqual(result.id, session.id)
+        self.assertEqual(result.title, "Owned Session")
+        self.assertEqual([item.type for item in result.history], ["message", "message", "output"])
+        self.assertEqual(result.history[0].id, user_message.id)
+        self.assertEqual(result.history[1].id, assistant_message.id)
+        self.assertEqual(
+            result.history[1].thinking_log,
+            "Summarized totals before answering.",
+        )
+        self.assertEqual(result.history[2].id, generated_output.id)
+        self.assertEqual(
+            result.history[2].thinking_log,
+            "Normalized columns and preserved totals.",
+        )
+
+    def test_build_resume_context_for_user_returns_none_for_missing_session(self):
+        result = build_resume_context_for_user(
+            self.owner,
+            "3208d1c1-e26f-4565-a2d8-b756b7f364c7",
+        )
+
+        self.assertIsNone(result)
+
+    def test_build_resume_context_for_user_returns_none_for_non_owned_session(self):
+        session = Session.objects.create(
+            owner=self.other_user,
+            title="Foreign Session",
+        )
+
+        result = build_resume_context_for_user(self.owner, session.id)
+
+        self.assertIsNone(result)
+
+    def test_build_resume_context_for_user_supports_minimal_or_partial_history(self):
+        session = Session.objects.create(
+            owner=self.owner,
+            title="Minimal Session",
+        )
+        GeneratedOutput.objects.create(
+            session=session,
+            output_json={
+                "document_info": {"source_type": "Excel", "filename": "minimal.xlsx"},
+                "summary": {"total_sheets": 1, "total_rows": 0, "total_columns": 0},
+                "content_data": [],
+            },
+            thinking_log="Only thinking log metadata is available.",
+            created_at=timezone.now() + timezone.timedelta(minutes=1),
+        )
+
+        result = build_resume_context_for_user(self.owner, session.id)
+
+        self.assertEqual(result.id, session.id)
+        self.assertEqual(len(result.history), 1)
+        self.assertEqual(result.history[0].type, "output")
+        self.assertEqual(
+            result.history[0].thinking_log,
+            "Only thinking log metadata is available.",
+        )
 
     def test_get_paginated_session_detail_for_user_rejects_invalid_limits(self):
         session = Session.objects.create(


### PR DESCRIPTION
## Summary

This task adds a dedicated resume endpoint for chat sessions so the frontend can restore a previous conversation context before continuing the chat flow.

This PR covers the agreed backend behavior:
- a session owner can resume an existing chat session through a dedicated endpoint
- the API returns session metadata together with chat-oriented history
- the returned history includes both stored chat messages and generated outputs
- `thinking_log` is included for history items that carry it
- missing or foreign sessions return `404`
- minimal or partial sessions still return the available context safely

The implemented behavior is:
- `GET /sessions/{session_id}/resume/` is now available
- resume payload is chat-oriented and not paginated like the generic session detail endpoint
- the endpoint only serves authenticated and verified users
- the endpoint only returns data for sessions owned by the requester
- history is returned in chronological order
- history can contain:
  - `message` items
  - `output` items

## Scope Covered

### Backend
- Updated `backend/chat_sessions/serializers.py`
  - added serializers for resume history items
  - added `SessionResumeSerializer`
- Updated `backend/chat_sessions/services.py`
  - added `build_resume_context_for_user(user, session_id)`
  - merges session messages and generated outputs into chronological resume history
- Updated `backend/api/views.py`
  - added `session_resume` endpoint handler
  - returns `404` for unknown or foreign sessions
  - serializes resume payload with `SessionResumeSerializer`
- Updated `backend/api/urls.py`
  - added route for `GET /sessions/{session_id}/resume/`

### Tests
- Added/updated tests in:
  - `backend/chat_sessions/tests/test_serializers.py`
  - `backend/chat_sessions/tests/test_services.py`
  - `backend/api/tests/test_views.py`

## Implemented Contract

### Resume Chat
- `GET /sessions/{session_id}/resume/`

Response body:
- `id`
- `title`
- `created_at`
- `updated_at`
- `last_message_at`
- `last_output_at`
- `history`

History item variants:
- `message`
  - `type`
  - `id`
  - `role`
  - `content`
  - `thinking_log`
  - `created_at`
- `output`
  - `type`
  - `id`
  - `output_json`
  - `thinking_log`
  - `created_at`

## Behavior Details

- authenticated and verified owner
  - receives `200 OK`
  - receives session metadata and chronological history
- unknown session id
  - returns `404`
- session owned by another user
  - returns `404`
- anonymous user
  - returns `401`
- authenticated but unverified user
  - returns `403`
- session with minimal or partial history
  - still returns `200`
  - returns only the available history items

## How to Test

### 1. Checkout Branch
```bash
git checkout feat/history-session-endpoint
```

### 2. Start Required Services
From repository root:
```bash
docker compose -f excel-generator-mono/docker-compose.dev.yml up -d
```

### 3. Run Backend Tests
From repository root:
```bash
docker compose -f excel-generator-mono/docker-compose.dev.yml exec backend python manage.py test --noinput chat_sessions.tests.test_serializers chat_sessions.tests.test_services api.tests.test_views.SessionEndpointTests
```

Expected:
- all scoped tests pass
- resume serializer returns the expected chat-oriented payload
- resume service returns owned session context in chronological order
- endpoint returns `200` for valid owned session
- endpoint returns `404` for unknown or foreign sessions
- endpoint returns `401` for anonymous access
- endpoint returns `403` for unverified users

### 4. Manual API Verification

1. Authenticate as a verified user.
2. Prepare or reuse an existing session that already contains messages or generated outputs.
3. Call:

```bash
GET /sessions/{session_id}/resume/
```

Expected:
- response contains session metadata
- `history` is ordered chronologically
- `thinking_log` is returned where applicable

### 5. Edge Case Verification

1. Resume a session with only one message.
2. Resume a session with only generated output.
3. Resume a session with partial history.

Expected:
- endpoint still returns `200`
- response contains only the available context
- no internal or foreign data is exposed

## Related Issues
- Resume previous chat session through API
- Restore session thinking log and chat context for continued conversation

## Author Checklist

- [x] Code follows team coding standards and style guide
- [x] Self-reviewed the code changes
- [x] Added/updated tests for new functionality
- [x] All scoped tests pass locally
- [x] Code is properly documented in MR description
- [ ] Synced with latest `main` branch
- [x] PR title follows conventional commit format
- [x] Meaningful commit messages used

## Additional Notes

- This PR is backend-only.
- This PR adds a dedicated resume endpoint and does not replace the generic session detail endpoint.
- Resume payload is intentionally chat-oriented and non-paginated so frontend chat state can be restored directly.
- The endpoint reuses persisted session data and does not mutate session state.

## Type of task

- [ ] Data Processing (for tasks involving data handling or manipulation)
- [ ] Model Training (for tasks involving model training)
- [x] API Development (for developing or serving model via API)
- [ ] UI Development (for developing or improving user interface)
- [x] Testing (for writing or updating tests)
- [ ] Debugging (for fixing errors or investigating issues)
- [x] Refactor (for code improvements without changing functionality)
- [ ] Performance Improvement / Optimization (for optimizations related to speed or efficiency)
- [ ] Security (for tasks related to security updates or patches)
- [x] Documentation (for updating or improving documentation)
- [ ] Monitoring (for adding or updating monitoring capabilities)
- [ ] All

## Reviewer(s)

- [ ] @username1
- [ ] @username2
- [ ] @username3