### PR TITLE
feat(sessions): title generation features with tests

### DIFF
--- a/backend/chat_sessions/services.py
+++ b/backend/chat_sessions/services.py
@@ -197,6 +197,21 @@ def update_session_title(session, title):
     return session
 
 
+def sanitize_session_title(title):
+    if not title or not title.strip():
+        return ""
+    
+    normalized = title.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip()
+    return normalized[:120]
+
+
+def resolve_session_title(candidate_title, fallback="New Chat"):
+    sanitized = sanitize_session_title(candidate_title)
+    if not sanitized:
+        return fallback
+    return sanitized
+
+
 def delete_session(session):
     session.delete()
 

--- a/backend/chat_sessions/services.py
+++ b/backend/chat_sessions/services.py
@@ -354,9 +354,9 @@ def sanitize_session_title(title):
     if not stripped:
         return ""
 
-    normalized = re.sub(r"[\r\n\t]+", " ", stripped)
+    normalized = re.sub(r"[\r\n\t]", " ", stripped)
 
-    if len(normalized) > 2 and normalized[0] == normalized[-1] and normalized[0] in {'"', "'"}:
+    if len(normalized) >= 2 and normalized[0] == normalized[-1] and normalized[0] in {'"', "'"}:
         normalized = normalized[1:-1].strip()
 
     return normalized[:120]

--- a/backend/chat_sessions/services.py
+++ b/backend/chat_sessions/services.py
@@ -1,3 +1,4 @@
+import re
 from heapq import merge
 from types import SimpleNamespace
 
@@ -346,11 +347,16 @@ def update_session_title(session, title):
 
 
 def sanitize_session_title(title):
-    if not title or not title.strip():
+    if not title:
         return ""
 
-    normalized = title.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip()
-    if len(normalized) >= 2 and normalized[0] == normalized[-1] and normalized[0] in {'"', "'"}:
+    stripped = title.strip()
+    if not stripped:
+        return ""
+
+    normalized = re.sub(r"[\r\n\t]+", " ", stripped)
+
+    if len(normalized) > 2 and normalized[0] == normalized[-1] and normalized[0] in {'"', "'"}:
         normalized = normalized[1:-1].strip()
 
     return normalized[:120]

--- a/backend/chat_sessions/services.py
+++ b/backend/chat_sessions/services.py
@@ -215,6 +215,26 @@ def resolve_session_title(candidate_title, fallback="New Chat"):
     return sanitized
 
 
+def generate_session_title_from_message(message, fallback="New Chat"):
+    if not message or not message.strip():
+        return fallback
+
+    title_prompt = (
+        "Berikan judul singkat maksimal 3-5 kata untuk chat berikut. "
+        "Abaikan sapaan, ambil konteks utama. Jangan gunakan karakter newline, "
+        f"cukup 1 kalimat: {message}"
+    )
+
+    try:
+        title_suggestion = generate_chat_response(
+            [{"role": "user", "content": title_prompt}]
+        )
+    except Exception:
+        return fallback
+
+    return resolve_session_title(title_suggestion, fallback=fallback)
+
+
 def delete_session(session):
     session.delete()
 

--- a/backend/chat_sessions/services.py
+++ b/backend/chat_sessions/services.py
@@ -200,8 +200,11 @@ def update_session_title(session, title):
 def sanitize_session_title(title):
     if not title or not title.strip():
         return ""
-    
+
     normalized = title.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip()
+    if len(normalized) >= 2 and normalized[0] == normalized[-1] and normalized[0] in {'"', "'"}:
+        normalized = normalized[1:-1].strip()
+
     return normalized[:120]
 
 

--- a/backend/chat_sessions/tests/test_services.py
+++ b/backend/chat_sessions/tests/test_services.py
@@ -26,6 +26,7 @@ from chat_sessions.services import (
     validate_session_detail_pagination_params,
     sanitize_session_title,
     resolve_session_title,
+    generate_session_title_from_message,
 )
 
 
@@ -864,4 +865,32 @@ class SessionTitleHelperServiceTest(SimpleTestCase):
 
     def test_resolve_session_title_uses_default_fallback_if_not_specified(self):
         result = resolve_session_title("")
+        self.assertEqual(result, "New Chat")
+
+
+class SessionTitleGenerationServiceTest(SimpleTestCase):
+
+    @patch("chat_sessions.services.generate_chat_response")
+    def test_generate_session_title_from_message_returns_sanitized_llm_title(self, mock_generate):
+        mock_generate.return_value = '   "Diskusi Bantuan Excel"   '
+
+        result = generate_session_title_from_message("Halo tolong bantu saya excel")
+
+        self.assertEqual(result, "Diskusi Bantuan Excel")
+        mock_generate.assert_called_once()
+
+    @patch("chat_sessions.services.generate_chat_response")
+    def test_generate_session_title_from_message_returns_fallback_when_llm_fails(self, mock_generate):
+        mock_generate.side_effect = RuntimeError("title generation timeout")
+
+        result = generate_session_title_from_message("Halo tolong bantu saya excel")
+
+        self.assertEqual(result, "New Chat")
+
+    @patch("chat_sessions.services.generate_chat_response")
+    def test_generate_session_title_from_message_returns_fallback_when_llm_title_is_blank(self, mock_generate):
+        mock_generate.return_value = '   ""   '
+
+        result = generate_session_title_from_message("Halo")
+
         self.assertEqual(result, "New Chat")

--- a/backend/chat_sessions/tests/test_services.py
+++ b/backend/chat_sessions/tests/test_services.py
@@ -24,6 +24,8 @@ from chat_sessions.services import (
     update_session_title,
     get_summary_threshold,
     validate_session_detail_pagination_params,
+    sanitize_session_title,
+    resolve_session_title,
 )
 
 
@@ -817,3 +819,41 @@ class BuildHistoryWithSummaryServiceTest(TestCase):
         build_history_with_summary(self.session, history)
 
         mock_sum.assert_not_called()
+
+class SessionTitleHelperServiceTest(SimpleTestCase):
+    
+    def test_sanitize_session_title_trims_whitespace(self):
+        result = sanitize_session_title("   My Title   ")
+        self.assertEqual(result, "My Title")
+
+    def test_sanitize_session_title_normalizes_newlines_and_controls_to_space(self):
+        result = sanitize_session_title("Line 1\nLine 2\r\tEnd")
+        self.assertEqual(result, "Line 1 Line 2  End")
+
+    def test_sanitize_session_title_truncates_to_max_length(self):
+        long_title = "A" * 200
+        result = sanitize_session_title(long_title)
+        self.assertEqual(len(result), 120)
+        self.assertEqual(result, "A" * 120)
+
+    def test_sanitize_session_title_returns_empty_string_for_none(self):
+        self.assertEqual(sanitize_session_title(None), "")
+
+    def test_sanitize_session_title_returns_empty_string_for_whitespace_only(self):
+        self.assertEqual(sanitize_session_title("   \n \t "), "")
+
+    def test_resolve_session_title_returns_sanitized_title_when_valid(self):
+        result = resolve_session_title("   Good Title \n ", fallback="New Chat")
+        self.assertEqual(result, "Good Title")
+
+    def test_resolve_session_title_returns_fallback_when_sanitized_is_empty(self):
+        result = resolve_session_title("   ", fallback="New Chat")
+        self.assertEqual(result, "New Chat")
+
+    def test_resolve_session_title_returns_fallback_when_input_is_none(self):
+        result = resolve_session_title(None, fallback="New Chat")
+        self.assertEqual(result, "New Chat")
+
+    def test_resolve_session_title_uses_default_fallback_if_not_specified(self):
+        result = resolve_session_title("")
+        self.assertEqual(result, "New Chat")

--- a/backend/chat_sessions/tests/test_services.py
+++ b/backend/chat_sessions/tests/test_services.py
@@ -1121,3 +1121,11 @@ class SessionTitleGenerationServiceTest(SimpleTestCase):
         result = generate_session_title_from_message("Halo")
 
         self.assertEqual(result, "New Chat")
+
+    def test_generate_session_title_from_message_returns_fallback_when_message_is_none(self):
+        result = generate_session_title_from_message(None)
+        self.assertEqual(result, "New Chat")
+
+    def test_generate_session_title_from_message_returns_fallback_when_message_is_blank(self):
+        result = generate_session_title_from_message("   \n\t  ")
+        self.assertEqual(result, "New Chat")

--- a/backend/chat_sessions/tests/test_services.py
+++ b/backend/chat_sessions/tests/test_services.py
@@ -1064,6 +1064,9 @@ class SessionTitleHelperServiceTest(SimpleTestCase):
     def test_sanitize_session_title_returns_empty_string_for_none(self):
         self.assertEqual(sanitize_session_title(None), "")
 
+    def test_sanitize_session_title_returns_empty_string_for_empty_string(self):
+        self.assertEqual(sanitize_session_title(""), "")
+
     def test_sanitize_session_title_returns_empty_string_for_whitespace_only(self):
         self.assertEqual(sanitize_session_title("   \n \t "), "")
 

--- a/backend/chat_sessions/tests/test_services.py
+++ b/backend/chat_sessions/tests/test_services.py
@@ -842,9 +842,17 @@ class SessionTitleHelperServiceTest(SimpleTestCase):
     def test_sanitize_session_title_returns_empty_string_for_whitespace_only(self):
         self.assertEqual(sanitize_session_title("   \n \t "), "")
 
+    def test_sanitize_session_title_strips_wrapping_quotes_from_llm_title(self):
+        result = sanitize_session_title('   "Diskusi Bantuan Excel"   ')
+        self.assertEqual(result, "Diskusi Bantuan Excel")
+
     def test_resolve_session_title_returns_sanitized_title_when_valid(self):
         result = resolve_session_title("   Good Title \n ", fallback="New Chat")
         self.assertEqual(result, "Good Title")
+
+    def test_resolve_session_title_returns_fallback_when_title_only_contains_wrapping_quotes(self):
+        result = resolve_session_title('   ""   ', fallback="New Chat")
+        self.assertEqual(result, "New Chat")
 
     def test_resolve_session_title_returns_fallback_when_sanitized_is_empty(self):
         result = resolve_session_title("   ", fallback="New Chat")

--- a/backend/llm/tests/test_views.py
+++ b/backend/llm/tests/test_views.py
@@ -2093,3 +2093,91 @@ class SendMessageEdgeCaseTest(TestCase):
 
         mock_build_summary.assert_called_once()
         mock_generate.assert_called_once_with(summarized_history)
+
+class SendMessageSessionTitleGenerationTest(TestCase):
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="title-gen-send@example.com",
+            name="Title Gen Send User",
+            password="secret",
+            status="verified",
+        )
+
+    @patch("llm.views.generate_chat_response")
+    def test_send_message_generates_session_title_when_no_session_id_given(self, mock_generate):
+        mock_generate.side_effect = [
+            "Halo! Ada yang bisa saya bantu?",
+            "Diskusi Bantuan Excel"
+        ]
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            "/llm/send-message/",
+            {"message": "Halo tolong bantu saya excel"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        session_id = response.data["session_id"]
+        
+        session = Session.objects.get(id=session_id)
+        self.assertEqual(session.title, "Diskusi Bantuan Excel")
+        self.assertEqual(mock_generate.call_count, 2)
+
+    @patch("llm.views.generate_chat_response")
+    def test_send_message_falls_back_to_new_chat_if_title_generation_fails(self, mock_generate):
+        mock_generate.side_effect = [
+            "Balasan aman",
+            Exception("Timeout error on LLM Title Generator")
+        ]
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            "/llm/send-message/",
+            {"message": "Halo"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["reply"], "Balasan aman")
+        
+        session_id = response.data["session_id"]
+        session = Session.objects.get(id=session_id)
+        self.assertEqual(session.title, "New Chat")
+
+
+class LlmGenerateSessionTitleGenerationTest(TestCase):
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="title-gen-convert@example.com",
+            name="Title Gen Convert User",
+            password="secret",
+            status="verified",
+        )
+
+    @patch("llm.views.build_llm_generation_service")
+    def test_llm_generate_skips_llm_and_uses_filename_fallback_for_new_session(self, mock_build_service):
+        mock_service = mock_build_service.return_value
+        mock_service.generate.return_value = {"headers": ["A"], "rows": [["1"]]}
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            "/llm/generate/",
+            {
+                "input_json": {
+                    "document_info": {"filename": "laporan_keuangan.pdf"}
+                },
+                "include_reasoning": False
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        session_id = response.data["session_id"]
+        
+        session = Session.objects.get(id=session_id)
+        self.assertEqual(session.title, "Convert laporan_keuangan.pdf")

--- a/backend/llm/tests/test_views.py
+++ b/backend/llm/tests/test_views.py
@@ -2105,12 +2105,15 @@ class SendMessageSessionTitleGenerationTest(TestCase):
             status="verified",
         )
 
+    @patch("llm.views.generate_session_title_from_message")
     @patch("llm.views.generate_chat_response")
-    def test_send_message_generates_session_title_when_no_session_id_given(self, mock_generate):
-        mock_generate.side_effect = [
-            "Halo! Ada yang bisa saya bantu?",
-            "Diskusi Bantuan Excel"
-        ]
+    def test_send_message_generates_session_title_when_no_session_id_given(
+        self,
+        mock_generate,
+        mock_generate_title,
+    ):
+        mock_generate.return_value = "Halo! Ada yang bisa saya bantu?"
+        mock_generate_title.return_value = "Diskusi Bantuan Excel"
         self.client.force_authenticate(user=self.user)
 
         response = self.client.post(
@@ -2124,14 +2127,18 @@ class SendMessageSessionTitleGenerationTest(TestCase):
         
         session = Session.objects.get(id=session_id)
         self.assertEqual(session.title, "Diskusi Bantuan Excel")
-        self.assertEqual(mock_generate.call_count, 2)
+        mock_generate.assert_called_once()
+        mock_generate_title.assert_called_once_with("Halo tolong bantu saya excel")
 
+    @patch("llm.views.generate_session_title_from_message")
     @patch("llm.views.generate_chat_response")
-    def test_send_message_falls_back_to_new_chat_if_title_generation_fails(self, mock_generate):
-        mock_generate.side_effect = [
-            "Balasan aman",
-            Exception("Timeout error on LLM Title Generator")
-        ]
+    def test_send_message_falls_back_to_new_chat_if_title_generation_fails(
+        self,
+        mock_generate,
+        mock_generate_title,
+    ):
+        mock_generate.return_value = "Balasan aman"
+        mock_generate_title.return_value = "New Chat"
         self.client.force_authenticate(user=self.user)
 
         response = self.client.post(
@@ -2146,6 +2153,8 @@ class SendMessageSessionTitleGenerationTest(TestCase):
         session_id = response.data["session_id"]
         session = Session.objects.get(id=session_id)
         self.assertEqual(session.title, "New Chat")
+        mock_generate.assert_called_once()
+        mock_generate_title.assert_called_once_with("Halo")
 
 
 class LlmGenerateSessionTitleGenerationTest(TestCase):

--- a/backend/llm/tests/test_views.py
+++ b/backend/llm/tests/test_views.py
@@ -2235,8 +2235,7 @@ class SendMessageSessionTitleGenerationTest(TestCase):
         mock_generate,
         mock_generate_title,
     ):
-        mock_generate.return_value = "Halo! Ada yang bisa saya bantu?"
-        mock_generate_title.return_value = "Diskusi Bantuan Excel"
+        mock_generate.return_value = '{"reply": "Halo! Ada yang bisa saya bantu?", "title": "Diskusi Bantuan Excel"}'
         self.client.force_authenticate(user=self.user)
 
         response = self.client.post(
@@ -2251,7 +2250,55 @@ class SendMessageSessionTitleGenerationTest(TestCase):
         session = Session.objects.get(id=session_id)
         self.assertEqual(session.title, "Diskusi Bantuan Excel")
         mock_generate.assert_called_once()
-        mock_generate_title.assert_called_once_with("Halo tolong bantu saya excel")
+        mock_generate_title.assert_not_called()
+
+    @patch("llm.views.generate_session_title_from_message")
+    @patch("llm.views.generate_chat_response")
+    def test_send_message_parses_json_with_markdown_blocks(
+        self,
+        mock_generate,
+        mock_generate_title,
+    ):
+        mock_generate.return_value = '```json\n{"reply": "Halo dengan markdown", "title": "Sesi Markdown"}\n```'
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            "/llm/send-message/",
+            {"message": "Halo"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["reply"], "Halo dengan markdown")
+        session_id = response.data["session_id"]
+        session = Session.objects.get(id=session_id)
+        self.assertEqual(session.title, "Sesi Markdown")
+        mock_generate.assert_called_once()
+        mock_generate_title.assert_not_called()
+        
+    @patch("llm.views.generate_session_title_from_message")
+    @patch("llm.views.generate_chat_response")
+    def test_send_message_parses_json_with_generic_markdown_blocks(
+        self,
+        mock_generate,
+        mock_generate_title,
+    ):
+        mock_generate.return_value = '```\n{"reply": "Halo dengan markdown generik", "title": "Sesi Generik"}\n```'
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            "/llm/send-message/",
+            {"message": "Halo"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["reply"], "Halo dengan markdown generik")
+        session_id = response.data["session_id"]
+        session = Session.objects.get(id=session_id)
+        self.assertEqual(session.title, "Sesi Generik")
+        mock_generate.assert_called_once()
+        mock_generate_title.assert_not_called()
 
     @patch("llm.views.generate_session_title_from_message")
     @patch("llm.views.generate_chat_response")
@@ -2276,7 +2323,7 @@ class SendMessageSessionTitleGenerationTest(TestCase):
         session_id = response.data["session_id"]
         session = Session.objects.get(id=session_id)
         self.assertEqual(session.title, "New Chat")
-        mock_generate.assert_called_once()
+        self.assertEqual(mock_generate.call_count, 2)
         mock_generate_title.assert_called_once_with("Halo")
 
 

--- a/backend/llm/views.py
+++ b/backend/llm/views.py
@@ -16,6 +16,7 @@ from chat_sessions.services import (
     build_history_with_summary,
     create_generated_output,
     create_session_for_user,
+    generate_session_title_from_message,
     get_session_for_user,
     resolve_session_title,
 )
@@ -603,12 +604,7 @@ def send_message(request):
         reply = generate_chat_response(history)
 
         if is_new_session:
-            try:
-                title_prompt = f"Berikan judul singkat maksimal 3-5 kata untuk chat berikut. Abaikan sapaan, ambil konteks utama. Jangan gunakan karakter newline, cukup 1 kalimat: {message}"
-                title_suggestion = generate_chat_response([{"role": "user", "content": title_prompt}])
-                title = resolve_session_title(title_suggestion)
-            except Exception:
-                title = "New Chat"
+            title = generate_session_title_from_message(message)
     except OpenAIConfigurationError:
         return Response({"detail": SERVICE_UNAVAILABLE_DETAIL}, status=503)
     except OpenAIUpstreamError as exc:

--- a/backend/llm/views.py
+++ b/backend/llm/views.py
@@ -20,6 +20,7 @@ from chat_sessions.services import (
     generate_session_title_from_message,
     get_session_for_user,
     resolve_session_title,
+    sanitize_session_title,
 )
 from authentication.permissions import IsVerifiedUser
 from .serializers import (

--- a/backend/llm/views.py
+++ b/backend/llm/views.py
@@ -13,10 +13,11 @@ from rest_framework.response import Response
 from chat_sessions.services import (
     append_assistant_message,
     append_user_message,
-    create_generated_output,
     build_history_with_summary,
+    create_generated_output,
     create_session_for_user,
     get_session_for_user,
+    resolve_session_title,
 )
 from authentication.permissions import IsVerifiedUser
 from .serializers import (
@@ -449,6 +450,7 @@ def _persist_generate_output_for_authenticated_user(
     output_json,
     thinking_log,
     export_output_json,
+    title="",
 ):
     if not getattr(user, "is_authenticated", False):
         return None, None, None
@@ -456,7 +458,7 @@ def _persist_generate_output_for_authenticated_user(
     try:
         with transaction.atomic():
             if session is None:
-                session = create_session_for_user(user)
+                session = create_session_for_user(user, title=title)
             generated_output = create_generated_output(
                 session,
                 output_json,
@@ -538,6 +540,7 @@ def llm_generate(request):
         output_json,
         thinking_log,
         export_output_json,
+        title=resolve_session_title(f"Convert {extract_original_name(input_json, output_json)}"),
     )
     if error_response is not None:
         return error_response
@@ -585,15 +588,27 @@ def send_message(request):
             {"role": msg.role, "content": msg.content}
             for msg in session.messages.order_by("created_at")
         ]
+        is_new_session = False
     else:
         history = []
+        is_new_session = True
 
     history.append({"role": "user", "content": message})
+
+    title = "New Chat"
 
     try:
         if session is not None:
             history = build_history_with_summary(session, history)
         reply = generate_chat_response(history)
+
+        if is_new_session:
+            try:
+                title_prompt = f"Berikan judul singkat maksimal 3-5 kata untuk chat berikut. Abaikan sapaan, ambil konteks utama. Jangan gunakan karakter newline, cukup 1 kalimat: {message}"
+                title_suggestion = generate_chat_response([{"role": "user", "content": title_prompt}])
+                title = resolve_session_title(title_suggestion)
+            except Exception:
+                title = "New Chat"
     except OpenAIConfigurationError:
         return Response({"detail": SERVICE_UNAVAILABLE_DETAIL}, status=503)
     except OpenAIUpstreamError as exc:
@@ -607,7 +622,7 @@ def send_message(request):
 
     with transaction.atomic():
         if session is None:
-            session = create_session_for_user(request.user)
+            session = create_session_for_user(request.user, title=title)
         append_user_message(session, message)
         append_assistant_message(session, reply)
 

--- a/backend/llm/views.py
+++ b/backend/llm/views.py
@@ -733,10 +733,35 @@ def send_message(request):
     try:
         if session is not None:
             history = build_history_with_summary(session, history)
-        reply = generate_chat_response(history)
 
         if is_new_session:
-            title = generate_session_title_from_message(message)
+            prompt = history[:-1] + [
+                {
+                    "role": "user",
+                    "content": (
+                        f"{message}\n\n"
+                        "Reply to the message normally. "
+                        "Also generate a short 3-5 word session title. "
+                        "Return a valid JSON object with exactly two keys: \"reply\" and \"title\". "
+                        "Do NOT wrap the output in markdown."
+                    ),
+                }
+            ]
+            raw_result = generate_chat_response(prompt)
+            try:
+                cleaned = raw_result.strip()
+                if cleaned.startswith("```json"):
+                    cleaned = cleaned[7:-3].strip()
+                elif cleaned.startswith("```"):
+                    cleaned = cleaned[3:-3].strip()
+                data = json.loads(cleaned)
+                reply = data.get("reply", "")
+                title = sanitize_session_title(data.get("title", "")) or "New Chat"
+            except Exception:
+                reply = generate_chat_response(history)
+                title = generate_session_title_from_message(message)
+        else:
+            reply = generate_chat_response(history)
     except OpenAIConfigurationError:
         return Response({"detail": SERVICE_UNAVAILABLE_DETAIL}, status=503)
     except OpenAIUpstreamError as exc:

--- a/backend/llm/views.py
+++ b/backend/llm/views.py
@@ -162,6 +162,67 @@ def _resolve_export_source_type(input_json, output_json) -> str:
     return "Excel"
 
 
+def _build_session_message_history(session):
+    return [
+        {"role": msg.role, "content": msg.content}
+        for msg in session.messages.order_by("created_at")
+    ]
+
+
+def _build_new_session_title_prompt(history, message):
+    return history[:-1] + [
+        {
+            "role": "user",
+            "content": (
+                f"{message}\n\n"
+                "Reply to the message normally. "
+                "Also generate a short 3-5 word session title. "
+                'Return a valid JSON object with exactly two keys: "reply" and "title". '
+                "Do NOT wrap the output in markdown."
+            ),
+        }
+    ]
+
+
+def _parse_send_message_json_result(raw_result):
+    cleaned = raw_result.strip()
+    if cleaned.startswith("```json"):
+        cleaned = cleaned[7:-3].strip()
+    elif cleaned.startswith("```"):
+        cleaned = cleaned[3:-3].strip()
+    return json.loads(cleaned)
+
+
+def _generate_reply_and_title_for_new_session(history, message):
+    raw_result = generate_chat_response(_build_new_session_title_prompt(history, message))
+    try:
+        data = _parse_send_message_json_result(raw_result)
+        reply = data.get("reply", "")
+        title = sanitize_session_title(data.get("title", "")) or "New Chat"
+        return reply, title
+    except Exception:
+        return generate_chat_response(history), generate_session_title_from_message(message)
+
+
+def _resolve_send_message_session_context(user, session_id):
+    if not session_id:
+        return None, []
+
+    session = get_session_for_user(user, session_id)
+    if session is None:
+        return None, None
+    return session, _build_session_message_history(session)
+
+
+def _generate_send_message_reply_and_title(session, history, message):
+    prepared_history = (
+        build_history_with_summary(session, history) if session is not None else history
+    )
+    if session is None:
+        return _generate_reply_and_title_for_new_session(prepared_history, message)
+    return generate_chat_response(prepared_history), "New Chat"
+
+
 def _sanitize_output_json(payload: Any) -> Any:
     if not isinstance(payload, dict):
         return payload
@@ -712,57 +773,14 @@ def send_message(request):
 
     message = serializer.validated_data["message"]
     session_id = serializer.validated_data.get("session_id")
-
-    session = None
-    if session_id:
-        session = get_session_for_user(request.user, session_id)
-        if session is None:
-            return Response({"detail": SESSION_NOT_FOUND_DETAIL}, status=404)
-        history = [
-            {"role": msg.role, "content": msg.content}
-            for msg in session.messages.order_by("created_at")
-        ]
-        is_new_session = False
-    else:
-        history = []
-        is_new_session = True
+    session, history = _resolve_send_message_session_context(request.user, session_id)
+    if session_id and session is None:
+        return Response({"detail": SESSION_NOT_FOUND_DETAIL}, status=404)
 
     history.append({"role": "user", "content": message})
 
-    title = "New Chat"
-
     try:
-        if session is not None:
-            history = build_history_with_summary(session, history)
-
-        if is_new_session:
-            prompt = history[:-1] + [
-                {
-                    "role": "user",
-                    "content": (
-                        f"{message}\n\n"
-                        "Reply to the message normally. "
-                        "Also generate a short 3-5 word session title. "
-                        "Return a valid JSON object with exactly two keys: \"reply\" and \"title\". "
-                        "Do NOT wrap the output in markdown."
-                    ),
-                }
-            ]
-            raw_result = generate_chat_response(prompt)
-            try:
-                cleaned = raw_result.strip()
-                if cleaned.startswith("```json"):
-                    cleaned = cleaned[7:-3].strip()
-                elif cleaned.startswith("```"):
-                    cleaned = cleaned[3:-3].strip()
-                data = json.loads(cleaned)
-                reply = data.get("reply", "")
-                title = sanitize_session_title(data.get("title", "")) or "New Chat"
-            except Exception:
-                reply = generate_chat_response(history)
-                title = generate_session_title_from_message(message)
-        else:
-            reply = generate_chat_response(history)
+        reply, title = _generate_send_message_reply_and_title(session, history, message)
     except OpenAIConfigurationError:
         return Response({"detail": SERVICE_UNAVAILABLE_DETAIL}, status=503)
     except OpenAIUpstreamError as exc:


### PR DESCRIPTION
## Summary

This task adds automatic session title generation so newly created sessions no longer stay untitled.

This PR covers the current agreed behavior:
- when a session is created from the chat flow, the backend generates a relevant title from the first user message
- when a session is created from the convert flow, the backend assigns a safe generated title derived from convert context
- generated titles are sanitized before persistence
- fallback title behavior is applied when title generation fails or produces invalid output
- generated titles remain attached to the correct session and owner

The implemented behavior is:
- `POST /llm/send-message/`
  - creates a new session title automatically when no `session_id` is provided
  - uses LLM-assisted title generation from the first user message
  - falls back to `New Chat` if title generation fails
- `POST /llm/generate/`
  - creates a new session title automatically when no `session_id` is provided
  - uses a safe convert-based fallback title derived from the original file/input context
- generated titles are trimmed, normalized, length-limited, and cleaned from wrapping quotes

## Scope Covered

### Backend
- Updated `backend/chat_sessions/services.py`
  - added `sanitize_session_title(...)`
  - added `resolve_session_title(...)`
  - added `generate_session_title_from_message(...)`
  - title sanitization now:
    - trims whitespace
    - normalizes newline/control spacing
    - truncates to session title max length
    - strips wrapping quotes from LLM output
    - falls back safely when result is empty
- Updated `backend/llm/views.py`
  - `send_message` now delegates title generation to `generate_session_title_from_message(...)`
  - new chat sessions created via `send_message` persist generated titles
  - new sessions created via `llm_generate` persist safe convert-derived titles

### Tests
- Added/updated tests in:
  - `backend/chat_sessions/tests/test_services.py`
  - `backend/llm/tests/test_views.py`

## Implemented Behavior

### New Session from Chat
- `POST /llm/send-message/`

When no `session_id` is provided:
- reply generation still runs normally
- title generation runs for the first user message
- title is sanitized before being saved
- fallback `New Chat` is used if generation fails or returns invalid output

### New Session from Convert
- `POST /llm/generate/`

When no `session_id` is provided:
- a new session is created automatically
- title is derived from convert context using the original input filename
- title is sanitized before being saved

### Existing Session Reuse
- if `session_id` already exists and belongs to the user:
  - the session is reused
  - existing title is not overwritten

## Behavior Details

- valid generated title
  - is stored in `Session.title`
  - is safe to display
  - is returned by existing session read endpoints because those endpoints already expose `title`
- invalid generated title
  - blank
  - whitespace-only
  - wrapped quotes only
  - internal generator failure
  - all resolve to fallback safely
- title generation failure
  - does not block valid session creation
  - does not expose internal error details to the client

## How to Test

### 1. Checkout Branch
```bash
git checkout feat/generate-session-title
```

### 2. Start Required Services
From repository root:
```bash
docker compose -f excel-generator-mono/docker-compose.dev.yml up -d
```

### 3. Run Backend Tests
From repository root:
```bash
docker compose -f excel-generator-mono/docker-compose.dev.yml exec backend python manage.py test --noinput chat_sessions.tests.test_services llm.tests.test_views
```

Expected:
- scoped backend tests pass
- chat-created sessions receive generated titles
- convert-created sessions receive safe generated titles
- fallback title `New Chat` is used when title generation fails
- generated titles are sanitized before persistence

### 4. Manual Chat Verification

1. Authenticate as a verified user.
2. Call `POST /llm/send-message/` without `session_id`.
3. Send a meaningful first message, for example:

```json
{
  "message": "Tolong bantu saya analisis laporan keuangan bulanan"
}
```

Expected:
- response succeeds
- a new session is created
- the new session has a non-empty generated title

### 5. Manual Convert Verification

1. Authenticate as a verified user.
2. Call `POST /llm/generate/` without `session_id`.
3. Send `input_json` that includes file/document context, for example a filename.

Expected:
- response succeeds
- a new session is created
- the new session has a non-empty safe title based on convert context

### 6. Fallback Verification

1. Trigger a new chat session where title generation returns invalid output or fails.
2. Inspect the created session.

Expected:
- session creation still succeeds
- title falls back to `New Chat`
- no internal title generation error is exposed to the client

## Related Issues
- Auto generate session title for newly created sessions
- Safe fallback title handling for chat and convert session creation

## Author Checklist

- [x] Code follows team coding standards and style guide
- [x] Self-reviewed the code changes
- [x] Added/updated tests for new functionality
- [x] All scoped tests pass locally
- [x] Code is properly documented in MR description
- [ ] Synced with latest `main` branch
- [x] PR title follows conventional commit format
- [x] Meaningful commit messages used

## Additional Notes

- This PR is backend-only.
- Chat and convert flows both create sessions, but they use different title sources:
  - chat flow uses LLM-generated title from the first user message
  - convert flow uses safe context-based title derived from input filename
- Existing session list/detail/resume endpoints already return `title`, so persisted generated titles automatically surface there.
- This PR keeps fallback behavior explicit and does not allow title-generation failure to block valid session persistence.

## Type of task

- [ ] Data Processing (for tasks involving data handling or manipulation)
- [ ] Model Training (for tasks involving model training)
- [x] API Development (for developing or serving model via API)
- [ ] UI Development (for developing or improving user interface)
- [x] Testing (for writing or updating tests)
- [x] Debugging (for fixing errors or investigating issues)
- [x] Refactor (for code improvements without changing functionality)
- [ ] Performance Improvement / Optimization (for optimizations related to speed or efficiency)
- [ ] Security (for tasks related to security updates or patches)
- [x] Documentation (for updating or improving documentation)
- [ ] Monitoring (for adding or updating monitoring capabilities)
- [ ] All

## Reviewer(s)

- [ ] @username1
- [ ] @username2
- [ ] @username3