### PR TITLE
Refactor and enhance monitoring access restrictions and tests

### DIFF
--- a/frontend/src/app/monitoring/page.tsx
+++ b/frontend/src/app/monitoring/page.tsx
@@ -1,12 +1,15 @@
 "use client"
 
 import AuthGuard from '@/components/AuthGuard'
+import MonitoringRoleGuard from '@/components/MonitoringRoleGuard'
 import MonitoringPage from './MonitoringPage'
 
 export default function Page() {
     return (
         <AuthGuard>
-            <MonitoringPage />
+            <MonitoringRoleGuard>
+                <MonitoringPage />
+            </MonitoringRoleGuard>
         </AuthGuard>
     )
 }

--- a/frontend/src/components/MonitoringRoleGuard.tsx
+++ b/frontend/src/components/MonitoringRoleGuard.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
+import { getMonitoringAccess } from '@/services/monitoring'
+
+type MonitoringRoleGuardProps = Readonly<{
+    children: ReactNode
+    redirectTo?: string
+    loadingFallback?: ReactNode
+}>
+
+export default function MonitoringRoleGuard({
+    children,
+    redirectTo = '/convert',
+    loadingFallback = null,
+}: MonitoringRoleGuardProps) {
+    const router = useRouter()
+    const [isChecking, setIsChecking] = useState(true)
+    const [isAuthorized, setIsAuthorized] = useState(false)
+
+    useEffect(() => {
+        let isCancelled = false
+
+        const verifyMonitoringAccess = async () => {
+            setIsChecking(true)
+
+            try {
+                const accessDecision = await getMonitoringAccess()
+
+                if (isCancelled) {
+                    return
+                }
+
+                if (!accessDecision.allowed) {
+                    setIsAuthorized(false)
+                    router.replace(redirectTo)
+                    return
+                }
+
+                setIsAuthorized(true)
+                setIsChecking(false)
+            } catch {
+                if (!isCancelled) {
+                    setIsAuthorized(false)
+                    router.replace(redirectTo)
+                }
+            }
+        }
+
+        void verifyMonitoringAccess()
+
+        return () => {
+            isCancelled = true
+        }
+    }, [redirectTo, router])
+
+    if (isChecking || !isAuthorized) {
+        return <>{loadingFallback}</>
+    }
+
+    return <>{children}</>
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { getStoredUser } from "@/lib/auth"
 import LogoutButton from "@/components/LogoutButton"
 import HistorySidebarList from "@/components/HistorySidebarList"
 import { useHistoryFiles } from '@/hooks/useHistoryFiles'
 import type { HistoryItem } from '@/services/history'
+import { getMonitoringAccess } from '@/services/monitoring'
 
 interface SidebarHistoryListState {
     readonly items: HistoryItem[]
@@ -26,17 +27,53 @@ interface SidebarProps {
     readonly historyListState?: SidebarHistoryListState
 }
 
+type SidebarMenuKey = Exclude<SidebarProps['activeMenu'], 'home' | 'history'>
+
+const SIDEBAR_MENUS: readonly {
+    readonly key: SidebarMenuKey
+    readonly label: string
+    readonly href: string
+}[] = [
+    { key: 'convert', label: 'Convert', href: '/convert' },
+    { key: 'schema', label: 'Schema', href: '/schema' },
+    { key: 'monitoring', label: 'Monitoring', href: '/monitoring' },
+    { key: 'change-password', label: 'Change Password', href: '/change-password' },
+]
+
 export default function Sidebar({ activeMenu, onLogout, selectedHistoryId, historyListState }: SidebarProps) {
-    const menus = [
-        { key: 'convert', label: 'Convert', href: '/convert' },
-        { key: 'schema', label: 'Schema', href: '/schema' },
-        { key: 'monitoring', label: 'Monitoring', href: '/monitoring' },
-        { key: 'change-password', label: 'Change Password', href: '/change-password' },
-    ]
+    const [canAccessMonitoring, setCanAccessMonitoring] = useState(false)
 
     const [username] = useState<string>(() => {
         return getStoredUser()?.name ?? 'User'
     })
+
+    useEffect(() => {
+        let isCancelled = false
+
+        const syncMonitoringAccess = async () => {
+            try {
+                const accessDecision = await getMonitoringAccess()
+
+                if (!isCancelled) {
+                    setCanAccessMonitoring(accessDecision.allowed)
+                }
+            } catch {
+                if (!isCancelled) {
+                    setCanAccessMonitoring(false)
+                }
+            }
+        }
+
+        void syncMonitoringAccess()
+
+        return () => {
+            isCancelled = true
+        }
+    }, [])
+
+    const visibleMenus = SIDEBAR_MENUS.filter((menu) => (
+        menu.key !== 'monitoring' || canAccessMonitoring
+    ))
 
     const localHistoryListState = useHistoryFiles({
         loadAll: true,
@@ -67,7 +104,7 @@ export default function Sidebar({ activeMenu, onLogout, selectedHistoryId, histo
             </div>
 
             <nav className="flex flex-col gap-1 px-3">
-                {menus.map((menu) => (
+                {visibleMenus.map((menu) => (
                     <a
                         key={menu.key}
                         href={menu.href}

--- a/frontend/tests/unit/components/MonitoringRoleGuard.test.tsx
+++ b/frontend/tests/unit/components/MonitoringRoleGuard.test.tsx
@@ -2,15 +2,24 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MonitoringRoleGuard from '@/components/MonitoringRoleGuard'
 
-const { mockReplace, mockGetMonitoringAccess } = vi.hoisted(() => ({
-    mockReplace: vi.fn(),
-    mockGetMonitoringAccess: vi.fn(),
-}))
+type MonitoringAccessDecision = {
+    allowed: boolean
+    reason: string
+}
+
+const { mockReplace, mockRouter, mockGetMonitoringAccess } = vi.hoisted(() => {
+    const replace = vi.fn()
+    return {
+        mockReplace: replace,
+        mockRouter: {
+            replace,
+        },
+        mockGetMonitoringAccess: vi.fn(),
+    }
+})
 
 vi.mock('next/navigation', () => ({
-    useRouter: () => ({
-        replace: mockReplace,
-    }),
+    useRouter: () => mockRouter,
 }))
 
 vi.mock('@/services/monitoring', () => ({
@@ -38,6 +47,7 @@ describe('MonitoringRoleGuard', () => {
         })
 
         expect(mockReplace).not.toHaveBeenCalled()
+        expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
     })
 
     it('redirects to /convert and hides children when monitoring access is denied', async () => {
@@ -57,6 +67,7 @@ describe('MonitoringRoleGuard', () => {
         })
 
         expect(screen.queryByTestId('monitoring-content')).not.toBeInTheDocument()
+        expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
     })
 
     it('redirects to /convert when the monitoring access check fails', async () => {
@@ -73,10 +84,25 @@ describe('MonitoringRoleGuard', () => {
         })
 
         expect(screen.queryByTestId('monitoring-content')).not.toBeInTheDocument()
+        expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps children hidden while monitoring access is pending', () => {
+        mockGetMonitoringAccess.mockReturnValue(new Promise(() => undefined))
+
+        render(
+            <MonitoringRoleGuard loadingFallback={<div data-testid="loading">Checking monitoring access</div>}>
+                <div data-testid="monitoring-content">Monitoring Content</div>
+            </MonitoringRoleGuard>
+        )
+
+        expect(screen.getByTestId('loading')).toBeInTheDocument()
+        expect(screen.queryByTestId('monitoring-content')).not.toBeInTheDocument()
+        expect(mockReplace).not.toHaveBeenCalled()
     })
 
     it('supports custom redirect and loading fallback', async () => {
-        let resolveAccess: ((value: { allowed: boolean; reason: string }) => void) | undefined
+        let resolveAccess: ((value: MonitoringAccessDecision) => void) | undefined
         mockGetMonitoringAccess.mockReturnValue(
             new Promise((resolve) => {
                 resolveAccess = resolve
@@ -105,7 +131,7 @@ describe('MonitoringRoleGuard', () => {
     })
 
     it('does not redirect after unmount when the access check resolves late', async () => {
-        let resolveAccess: ((value: { allowed: boolean; reason: string }) => void) | undefined
+        let resolveAccess: ((value: MonitoringAccessDecision) => void) | undefined
         mockGetMonitoringAccess.mockReturnValue(
             new Promise((resolve) => {
                 resolveAccess = resolve

--- a/frontend/tests/unit/components/MonitoringRoleGuard.test.tsx
+++ b/frontend/tests/unit/components/MonitoringRoleGuard.test.tsx
@@ -153,4 +153,25 @@ describe('MonitoringRoleGuard', () => {
 
         expect(mockReplace).not.toHaveBeenCalled()
     })
+
+    it('does not redirect after unmount when the access check rejects late', async () => {
+        let rejectAccess: ((reason?: unknown) => void) | undefined
+        mockGetMonitoringAccess.mockReturnValue(
+            new Promise((_, reject) => {
+                rejectAccess = reject
+            })
+        )
+
+        const { unmount } = render(
+            <MonitoringRoleGuard>
+                <div data-testid="monitoring-content">Monitoring Content</div>
+            </MonitoringRoleGuard>
+        )
+
+        unmount()
+        rejectAccess?.(new Error('late monitoring access failure'))
+        await Promise.resolve()
+
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
 })

--- a/frontend/tests/unit/components/MonitoringRoleGuard.test.tsx
+++ b/frontend/tests/unit/components/MonitoringRoleGuard.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MonitoringRoleGuard from '@/components/MonitoringRoleGuard'
+
+const { mockReplace, mockGetMonitoringAccess } = vi.hoisted(() => ({
+    mockReplace: vi.fn(),
+    mockGetMonitoringAccess: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({
+        replace: mockReplace,
+    }),
+}))
+
+vi.mock('@/services/monitoring', () => ({
+    getMonitoringAccess: () => mockGetMonitoringAccess(),
+}))
+
+describe('MonitoringRoleGuard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetMonitoringAccess.mockResolvedValue({
+            allowed: true,
+            reason: 'ok',
+        })
+    })
+
+    it('renders children when monitoring access is allowed', async () => {
+        render(
+            <MonitoringRoleGuard>
+                <div data-testid="monitoring-content">Monitoring Content</div>
+            </MonitoringRoleGuard>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monitoring-content')).toBeInTheDocument()
+        })
+
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('redirects to /convert and hides children when monitoring access is denied', async () => {
+        mockGetMonitoringAccess.mockResolvedValue({
+            allowed: false,
+            reason: 'no_account',
+        })
+
+        render(
+            <MonitoringRoleGuard>
+                <div data-testid="monitoring-content">Monitoring Content</div>
+            </MonitoringRoleGuard>
+        )
+
+        await waitFor(() => {
+            expect(mockReplace).toHaveBeenCalledWith('/convert')
+        })
+
+        expect(screen.queryByTestId('monitoring-content')).not.toBeInTheDocument()
+    })
+
+    it('redirects to /convert when the monitoring access check fails', async () => {
+        mockGetMonitoringAccess.mockRejectedValue(new Error('network down'))
+
+        render(
+            <MonitoringRoleGuard>
+                <div data-testid="monitoring-content">Monitoring Content</div>
+            </MonitoringRoleGuard>
+        )
+
+        await waitFor(() => {
+            expect(mockReplace).toHaveBeenCalledWith('/convert')
+        })
+
+        expect(screen.queryByTestId('monitoring-content')).not.toBeInTheDocument()
+    })
+
+    it('supports custom redirect and loading fallback', async () => {
+        let resolveAccess: ((value: { allowed: boolean; reason: string }) => void) | undefined
+        mockGetMonitoringAccess.mockReturnValue(
+            new Promise((resolve) => {
+                resolveAccess = resolve
+            })
+        )
+
+        render(
+            <MonitoringRoleGuard
+                redirectTo="/custom-convert"
+                loadingFallback={<div data-testid="loading">Checking monitoring access</div>}
+            >
+                <div data-testid="monitoring-content">Monitoring Content</div>
+            </MonitoringRoleGuard>
+        )
+
+        expect(screen.getByTestId('loading')).toBeInTheDocument()
+
+        resolveAccess?.({
+            allowed: false,
+            reason: 'inactive',
+        })
+
+        await waitFor(() => {
+            expect(mockReplace).toHaveBeenCalledWith('/custom-convert')
+        })
+    })
+
+    it('does not redirect after unmount when the access check resolves late', async () => {
+        let resolveAccess: ((value: { allowed: boolean; reason: string }) => void) | undefined
+        mockGetMonitoringAccess.mockReturnValue(
+            new Promise((resolve) => {
+                resolveAccess = resolve
+            })
+        )
+
+        const { unmount } = render(
+            <MonitoringRoleGuard>
+                <div data-testid="monitoring-content">Monitoring Content</div>
+            </MonitoringRoleGuard>
+        )
+
+        unmount()
+        resolveAccess?.({
+            allowed: false,
+            reason: 'no_account',
+        })
+        await Promise.resolve()
+
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/tests/unit/components/Sidebar.test.tsx
+++ b/frontend/tests/unit/components/Sidebar.test.tsx
@@ -100,6 +100,43 @@ describe('Sidebar', () => {
         expect(screen.queryByRole('link', { name: 'Monitoring' })).not.toBeInTheDocument()
     })
 
+    it('does not update Monitoring visibility after unmount when access resolves late', async () => {
+        let resolveAccess: ((value: { allowed: boolean; reason: string }) => void) | undefined
+        mockGetMonitoringAccess.mockReturnValue(
+            new Promise((resolve) => {
+                resolveAccess = resolve
+            })
+        )
+
+        const { unmount } = render(<Sidebar activeMenu="convert" />)
+
+        unmount()
+        resolveAccess?.({
+            allowed: true,
+            reason: 'ok',
+        })
+        await Promise.resolve()
+
+        expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not update Monitoring visibility after unmount when access rejects late', async () => {
+        let rejectAccess: ((reason?: unknown) => void) | undefined
+        mockGetMonitoringAccess.mockReturnValue(
+            new Promise((_, reject) => {
+                rejectAccess = reject
+            })
+        )
+
+        const { unmount } = render(<Sidebar activeMenu="convert" />)
+
+        unmount()
+        rejectAccess?.(new Error('late monitoring access failure'))
+        await Promise.resolve()
+
+        expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
+    })
+
     it('renders Monitoring menu when the user has monitoring access', async () => {
         mockGetMonitoringAccess.mockResolvedValue({
             allowed: true,

--- a/frontend/tests/unit/components/Sidebar.test.tsx
+++ b/frontend/tests/unit/components/Sidebar.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import * as auth from '@/lib/auth'
 import Sidebar from '../../../src/components/Sidebar'
 import { useHistoryFiles } from '@/hooks/useHistoryFiles'
+import { getMonitoringAccess } from '@/services/monitoring'
 
 vi.mock('@/hooks/useHistoryFiles', () => ({
     useHistoryFiles: vi.fn(),
@@ -16,7 +17,12 @@ vi.mock('@/components/HistorySidebarList', () => ({
     default: () => <div data-testid="history-sidebar-list">History Sidebar List</div>,
 }))
 
+vi.mock('@/services/monitoring', () => ({
+    getMonitoringAccess: vi.fn(),
+}))
+
 const mockUseHistoryFiles = vi.mocked(useHistoryFiles)
+const mockGetMonitoringAccess = vi.mocked(getMonitoringAccess)
 
 function makeHistoryHookState() {
     return {
@@ -44,7 +50,12 @@ function makeHistoryHookState() {
 
 describe('Sidebar', () => {
     beforeEach(() => {
+        vi.clearAllMocks()
         mockUseHistoryFiles.mockReturnValue(makeHistoryHookState())
+        mockGetMonitoringAccess.mockResolvedValue({
+            allowed: false,
+            reason: 'no_account',
+        })
     })
 
     it('renders brand name EQUITEK', () => {
@@ -57,12 +68,25 @@ describe('Sidebar', () => {
         expect(screen.getByText('EQUITEK')).toHaveAttribute('href', '/')
     })
 
-    it('renders Convert, Schema, Monitoring, and Change Password menu', () => {
+    it('renders non-monitoring menus by default', () => {
         render(<Sidebar activeMenu="convert" />)
         expect(screen.getByText('Convert')).toBeInTheDocument()
         expect(screen.getByText('Schema')).toBeInTheDocument()
-        expect(screen.getByText('Monitoring')).toBeInTheDocument()
         expect(screen.getByText('Change Password')).toBeInTheDocument()
+        expect(screen.queryByText('Monitoring')).not.toBeInTheDocument()
+    })
+
+    it('renders Monitoring menu when the user has monitoring access', async () => {
+        mockGetMonitoringAccess.mockResolvedValue({
+            allowed: true,
+            reason: 'ok',
+        })
+
+        render(<Sidebar activeMenu="convert" />)
+
+        await waitFor(() => {
+            expect(screen.getByText('Monitoring')).toBeInTheDocument()
+        })
     })
 
     it('does not render History as a separate top menu label', () => {
@@ -95,9 +119,17 @@ describe('Sidebar', () => {
         expect(screen.getByText('Change Password').closest('a')).toHaveClass('bg-white')
     })
 
-    it('marks Monitoring as active when activeMenu is monitoring', () => {
+    it('marks Monitoring as active when activeMenu is monitoring and access is allowed', async () => {
+        mockGetMonitoringAccess.mockResolvedValue({
+            allowed: true,
+            reason: 'ok',
+        })
+
         render(<Sidebar activeMenu="monitoring" />)
-        expect(screen.getByText('Monitoring').closest('a')).toHaveClass('bg-white')
+
+        await waitFor(() => {
+            expect(screen.getByText('Monitoring').closest('a')).toHaveClass('bg-white')
+        })
     })
 
     it('renders stored user name at the bottom', () => {

--- a/frontend/tests/unit/components/Sidebar.test.tsx
+++ b/frontend/tests/unit/components/Sidebar.test.tsx
@@ -68,12 +68,36 @@ describe('Sidebar', () => {
         expect(screen.getByText('EQUITEK')).toHaveAttribute('href', '/')
     })
 
-    it('renders non-monitoring menus by default', () => {
+    it('keeps Monitoring hidden when monitoring access is denied', async () => {
         render(<Sidebar activeMenu="convert" />)
         expect(screen.getByText('Convert')).toBeInTheDocument()
         expect(screen.getByText('Schema')).toBeInTheDocument()
         expect(screen.getByText('Change Password')).toBeInTheDocument()
         expect(screen.queryByText('Monitoring')).not.toBeInTheDocument()
+
+        await waitFor(() => {
+            expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
+        })
+        expect(screen.queryByText('Monitoring')).not.toBeInTheDocument()
+    })
+
+    it('keeps Monitoring hidden while monitoring access is still loading', () => {
+        mockGetMonitoringAccess.mockReturnValue(new Promise(() => undefined))
+
+        render(<Sidebar activeMenu="convert" />)
+
+        expect(screen.queryByRole('link', { name: 'Monitoring' })).not.toBeInTheDocument()
+    })
+
+    it('keeps Monitoring hidden when monitoring access cannot be checked', async () => {
+        mockGetMonitoringAccess.mockRejectedValue(new Error('monitoring access unavailable'))
+
+        render(<Sidebar activeMenu="convert" />)
+
+        await waitFor(() => {
+            expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
+        })
+        expect(screen.queryByRole('link', { name: 'Monitoring' })).not.toBeInTheDocument()
     })
 
     it('renders Monitoring menu when the user has monitoring access', async () => {
@@ -85,8 +109,9 @@ describe('Sidebar', () => {
         render(<Sidebar activeMenu="convert" />)
 
         await waitFor(() => {
-            expect(screen.getByText('Monitoring')).toBeInTheDocument()
+            expect(screen.getByRole('link', { name: 'Monitoring' })).toHaveAttribute('href', '/monitoring')
         })
+        expect(mockGetMonitoringAccess).toHaveBeenCalledTimes(1)
     })
 
     it('does not render History as a separate top menu label', () => {

--- a/frontend/tests/unit/pages/MonitoringRoutePage.test.tsx
+++ b/frontend/tests/unit/pages/MonitoringRoutePage.test.tsx
@@ -9,14 +9,21 @@ vi.mock('../../../src/components/AuthGuard', () => ({
     ),
 }))
 
+vi.mock('../../../src/components/MonitoringRoleGuard', () => ({
+    default: ({ children }: { children: ReactNode }) => (
+        <div data-testid="monitoring-role-guard">{children}</div>
+    ),
+}))
+
 vi.mock('../../../src/app/monitoring/MonitoringPage', () => ({
     default: () => <div data-testid="monitoring-page" />,
 }))
 
 describe('Monitoring route page wrapper', () => {
-    it('wraps MonitoringPage with AuthGuard', () => {
+    it('wraps MonitoringPage with AuthGuard and MonitoringRoleGuard', () => {
         render(<Page />)
         expect(screen.getByTestId('auth-guard')).toBeInTheDocument()
+        expect(screen.getByTestId('monitoring-role-guard')).toBeInTheDocument()
         expect(screen.getByTestId('monitoring-page')).toBeInTheDocument()
     })
 })


### PR DESCRIPTION
<!-- Use [**Conventional Commits**](https://www.conventionalcommits.org/en/v1.0.0/) format for PR titles:

```
<type>(<scope>): <description>
```

### **Common Types:**

* `feat`: New feature
* `fix`: Bug fix
* `docs`: Documentation changes
* `style`: Code style changes (formatting, no logic changes)
* `refactor`: Code refactoring
* `test`: Adding or updating tests
* `chore`: Maintenance tasks, dependency updates

### **Description Field:**

* Recommended to start a \<description\> with a verb (add, resolve, update, etc.)

### **Examples:**

* `feat(auth): add OAuth2 login integration`
* `fix(api): resolve null pointer exception in user service`
* `docs(readme): update installation instructions`
* `refactor(database): optimize query performance`
* `feat(BE): add vector DB connection`
* `fix(FE): login redirection` -->

## Summary


This pull request introduces robust role-based access control for the Monitoring feature in the frontend. It adds a new `MonitoringRoleGuard` component to restrict access to the Monitoring page based on user permissions, updates the Sidebar to conditionally show the Monitoring menu item, and provides comprehensive unit tests for these changes.

**Access control for Monitoring:**

- Added a new `MonitoringRoleGuard` component that checks a user's monitoring access before rendering its children, redirects unauthorized users, and handles loading states. (`frontend/src/components/MonitoringRoleGuard.tsx`)
- Wrapped the Monitoring page in `MonitoringRoleGuard` to enforce access checks at the route level. (`frontend/src/app/monitoring/page.tsx`)

**Sidebar menu visibility:**

- Updated the Sidebar to check monitoring access asynchronously and only display the Monitoring menu item if the user is authorized. (`frontend/src/components/Sidebar.tsx`) [[1]](diffhunk://#diff-9c027098d7ec0a7bbd0da1505a03bc94e3e1863be39d3401a4c5aa9fad986709L4-R10) [[2]](diffhunk://#diff-9c027098d7ec0a7bbd0da1505a03bc94e3e1863be39d3401a4c5aa9fad986709L29-R77) [[3]](diffhunk://#diff-9c027098d7ec0a7bbd0da1505a03bc94e3e1863be39d3401a4c5aa9fad986709L70-R107)

**Testing:**

- Added extensive unit tests for `MonitoringRoleGuard`, covering allowed/denied access, loading states, redirects, and unmount behavior. (`frontend/tests/unit/components/MonitoringRoleGuard.test.tsx`)
- Updated Sidebar tests to cover conditional rendering of the Monitoring menu based on access, including loading and error scenarios. (`frontend/tests/unit/components/Sidebar.test.tsx`) [[1]](diffhunk://#diff-e35896a9f39391425a250cefce2c95f68246e272e95e031b29fcfc77903cb59fL1-R6) [[2]](diffhunk://#diff-e35896a9f39391425a250cefce2c95f68246e272e95e031b29fcfc77903cb59fR20-R25) [[3]](diffhunk://#diff-e35896a9f39391425a250cefce2c95f68246e272e95e031b29fcfc77903cb59fR53-R58) [[4]](diffhunk://#diff-e35896a9f39391425a250cefce2c95f68246e272e95e031b29fcfc77903cb59fL60-R114) [[5]](diffhunk://#diff-e35896a9f39391425a250cefce2c95f68246e272e95e031b29fcfc77903cb59fL98-R158)
- Adjusted the Monitoring route page test to verify that both `AuthGuard` and `MonitoringRoleGuard` wrap the page. (`frontend/tests/unit/pages/MonitoringRoutePage.test.tsx`)

## How to Test

<!--- Steps to manually test or verify functionality-->

1. Clone and run the repository
2. Check now normal  user cant see and access the monitoring dashboard

## Related Issues

#250 

## Author Checklist

- [x] Code follows team coding standards and style guide
- [x] Self-reviewed the code changes
- [x] Added/updated tests for new functionality
- [x] All tests pass locally
- [ ] Code is properly documented
- [x] Synced with latest `main` branch
- [x] PR title follows conventional commit format
- [x] Meaningful commit messages used

## Additional Notes

<!-- Any additional context, screenshots, or information reviewers should know -->

## Type of task

<!--- Please checklist options that are relevant -->

- [ ] Data Processing (for tasks involving data handling or manipulation)
- [ ] Model Training (for tasks involving model training)
- [ ] API Development (for developing or serving model via API)
- [ ] UI Development (for developing or improving user interface)
- [ ] Testing (for writing or updating tests)
- [ ] Debugging (for fixing errors or investigating issues)
- [ ] Refactor (for code improvements without changing functionality)
- [ ] Performance Improvement / Optimization (for optimizations related to speed or efficiency)
- [ ] Security (for tasks related to security updates or patches)
- [ ] Documentation (for updating or improving documentation)
- [x] Monitoring (for adding or updating monitoring capabilities)
- [ ] All

## Reviewer(s)

<!--- Please add the names or GitHub usernames of the reviewers -->

- [ ] @zufarra 
