### PR TITLE
refactor: Refactor and add tests for message serialization and streaming

### DIFF
--- a/backend/llm/serializers.py
+++ b/backend/llm/serializers.py
@@ -236,33 +236,26 @@ class LlmGenerateResponseSerializer(serializers.Serializer):
         return value
 
 
-class SendMessageRequestSerializer(serializers.Serializer):
+class BaseMessageRequestSerializer(serializers.Serializer):
     session_id = serializers.UUIDField(required=False, allow_null=True)
+    message = serializers.CharField(
+        max_length=MAX_MESSAGE_LENGTH,
+        allow_blank=False,
+        trim_whitespace=False,
+    )
+
+    def validate_message(self, value):
+        if not value.strip():
+            raise serializers.ValidationError("This field may not be blank.")
+        return value
+
+
+class SendMessageRequestSerializer(BaseMessageRequestSerializer):
     target_output_id = serializers.UUIDField(required=False, allow_null=True)
-    message = serializers.CharField(
-        max_length=MAX_MESSAGE_LENGTH,
-        allow_blank=False,
-        trim_whitespace=False,
-    )
-
-    def validate_message(self, value):
-        if not value.strip():
-            raise serializers.ValidationError("This field may not be blank.")
-        return value
 
 
-class StreamSendMessageRequestSerializer(serializers.Serializer):
-    session_id = serializers.UUIDField(required=False, allow_null=True)
-    message = serializers.CharField(
-        max_length=MAX_MESSAGE_LENGTH,
-        allow_blank=False,
-        trim_whitespace=False,
-    )
-
-    def validate_message(self, value):
-        if not value.strip():
-            raise serializers.ValidationError("This field may not be blank.")
-        return value
+class StreamSendMessageRequestSerializer(BaseMessageRequestSerializer):
+    pass
 
 
 class SendMessageResponseSerializer(serializers.Serializer):

--- a/backend/llm/services/openai_client.py
+++ b/backend/llm/services/openai_client.py
@@ -139,25 +139,22 @@ def _generate_text_via_chat_completions(
     return normalized_content
 
 
+def _extract_text_from_content_item(item: Any) -> str | None:
+    if isinstance(item, dict):
+        candidate = item.get("text") or item.get("content")
+    else:
+        candidate = getattr(item, "text", None) or getattr(item, "content", None)
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+    return None
+
+
 def _normalize_chat_message_content(content: Any) -> str | None:
     if isinstance(content, str):
-        normalized_content = content.strip()
-        return normalized_content or None
-
+        return content.strip() or None
     if isinstance(content, list):
-        chunks: list[str] = []
-        for item in content:
-            if isinstance(item, dict):
-                text_candidate = item.get("text") or item.get("content")
-            else:
-                text_candidate = getattr(item, "text", None) or getattr(item, "content", None)
-
-            if isinstance(text_candidate, str) and text_candidate.strip():
-                chunks.append(text_candidate.strip())
-
-        merged_content = "\n".join(chunks).strip()
-        return merged_content or None
-
+        chunks = [t for item in content if (t := _extract_text_from_content_item(item))]
+        return "\n".join(chunks).strip() or None
     return None
 
 

--- a/backend/llm/tests/test_serializers.py
+++ b/backend/llm/tests/test_serializers.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from django.utils import timezone
 
 from llm.serializers import (
+    BaseMessageRequestSerializer,
     LlmGenerateRequestSerializer,
     LlmGenerateResponseSerializer,
     LlmReasoningRequestSerializer,
@@ -702,6 +703,38 @@ class SendMessageSerializerTest(SimpleTestCase):
         serializer = ThinkingLogItemSerializer(instance)
 
         self.assertEqual(serializer.data["reasoning"], ["Step one", "Step two"])
+
+
+class BaseMessageRequestSerializerTest(SimpleTestCase):
+    def test_positive_valid_message(self):
+        s = BaseMessageRequestSerializer(data={"message": "hello"})
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_negative_blank_message(self):
+        s = BaseMessageRequestSerializer(data={"message": "   "})
+        self.assertFalse(s.is_valid())
+        self.assertIn("message", s.errors)
+
+    def test_negative_missing_message(self):
+        s = BaseMessageRequestSerializer(data={})
+        self.assertFalse(s.is_valid())
+        self.assertIn("message", s.errors)
+
+    def test_edge_optional_session_id_accepted(self):
+        sid = str(uuid4())
+        s = BaseMessageRequestSerializer(data={"message": "hi", "session_id": sid})
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_edge_send_message_still_accepts_target_output_id(self):
+        sid = str(uuid4())
+        s = SendMessageRequestSerializer(data={"message": "hi", "target_output_id": sid})
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_edge_stream_serializer_ignores_target_output_id(self):
+        sid = str(uuid4())
+        s = StreamSendMessageRequestSerializer(data={"message": "hi", "target_output_id": sid})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertNotIn("target_output_id", s.validated_data)
 
 
 class StreamSendMessageSerializerTest(SimpleTestCase):

--- a/backend/llm/tests/test_services.py
+++ b/backend/llm/tests/test_services.py
@@ -14,6 +14,7 @@ from llm.services.generation_service import (
 from llm.services.openai_client import (
     OpenAIServiceError,
     OpenAIUpstreamError,
+    _extract_text_from_content_item,
     generate_chat_response,
     generate_json,
     generate_streaming_chat_response,
@@ -1033,3 +1034,41 @@ class GenerateStreamingChatResponseTest(SimpleTestCase):
         list(generate_streaming_chat_response([{"role": "user", "content": "Hi"}]))
 
         mock_openai.assert_called_once_with(api_key="test-key")
+
+
+class ExtractTextFromContentItemTest(SimpleTestCase):
+    def test_positive_extracts_text_key_from_dict(self):
+        result = _extract_text_from_content_item({"text": "hello"})
+        self.assertEqual(result, "hello")
+
+    def test_positive_extracts_content_key_from_dict(self):
+        result = _extract_text_from_content_item({"content": "world"})
+        self.assertEqual(result, "world")
+
+    def test_positive_extracts_text_attr_from_object(self):
+        result = _extract_text_from_content_item(SimpleNamespace(text="hi"))
+        self.assertEqual(result, "hi")
+
+    def test_positive_extracts_content_attr_from_object(self):
+        result = _extract_text_from_content_item(SimpleNamespace(content="there"))
+        self.assertEqual(result, "there")
+
+    def test_positive_strips_whitespace(self):
+        result = _extract_text_from_content_item({"text": "  trimmed  "})
+        self.assertEqual(result, "trimmed")
+
+    def test_negative_returns_none_for_blank_text(self):
+        result = _extract_text_from_content_item({"text": "   "})
+        self.assertIsNone(result)
+
+    def test_negative_returns_none_when_no_text_or_content_key(self):
+        result = _extract_text_from_content_item({"other": "value"})
+        self.assertIsNone(result)
+
+    def test_negative_returns_none_for_non_string_text(self):
+        result = _extract_text_from_content_item({"text": 123})
+        self.assertIsNone(result)
+
+    def test_edge_prefers_text_over_content_key(self):
+        result = _extract_text_from_content_item({"text": "from-text", "content": "from-content"})
+        self.assertEqual(result, "from-text")

--- a/backend/llm/tests/test_streaming_views.py
+++ b/backend/llm/tests/test_streaming_views.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from unittest.mock import MagicMock, patch
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from rest_framework.test import APIClient
 from authentication.models import User
 from chat_sessions.models import Session
@@ -355,3 +355,97 @@ class StreamSendMessageNegativeSessionTest(TestCase):
         mock_logger.exception.assert_called_once_with(
             "Unexpected error during streaming send_message."
         )
+
+
+class BuildSseEventTest(SimpleTestCase):
+    def test_positive_formats_chunk_event(self):
+        from llm.views import _build_sse_event
+        result = _build_sse_event({"chunk": "hello"})
+        self.assertEqual(result, 'data: {"chunk": "hello"}\n\n')
+
+    def test_positive_formats_error_event(self):
+        from llm.views import _build_sse_event
+        result = _build_sse_event({"error": "failed"})
+        self.assertEqual(result, 'data: {"error": "failed"}\n\n')
+
+    def test_positive_formats_done_event(self):
+        from llm.views import _build_sse_event
+        result = _build_sse_event({"session_id": "abc-123", "done": True})
+        parsed = json.loads(result[6:].strip())
+        self.assertEqual(parsed, {"session_id": "abc-123", "done": True})
+
+    def test_edge_empty_dict_produces_valid_sse_line(self):
+        from llm.views import _build_sse_event
+        result = _build_sse_event({})
+        self.assertTrue(result.startswith("data: "))
+        self.assertTrue(result.endswith("\n\n"))
+
+
+class PrepareStreamHistoryTest(SimpleTestCase):
+    def test_positive_returns_history_unchanged_when_no_session(self):
+        from llm.views import _prepare_stream_history
+        history = [{"role": "user", "content": "hi"}]
+        result = _prepare_stream_history(None, history)
+        self.assertEqual(result, history)
+
+    @patch("llm.views._inject_file_context_if_available")
+    @patch("llm.views.build_history_with_summary")
+    def test_positive_calls_build_history_and_inject_when_session_exists(
+        self, mock_build, mock_inject
+    ):
+        from llm.views import _prepare_stream_history
+        mock_build.return_value = [{"role": "user", "content": "summarized"}]
+        mock_inject.return_value = [{"role": "system", "content": "ctx"}, {"role": "user", "content": "summarized"}]
+
+        session = MagicMock()
+        history = [{"role": "user", "content": "hi"}]
+        result = _prepare_stream_history(session, history)
+
+        mock_build.assert_called_once_with(session, history)
+        mock_inject.assert_called_once_with(session, mock_build.return_value)
+        self.assertEqual(result, mock_inject.return_value)
+
+    @patch("llm.views._inject_file_context_if_available")
+    @patch("llm.views.build_history_with_summary")
+    def test_negative_does_not_call_build_history_when_session_is_none(
+        self, mock_build, mock_inject
+    ):
+        from llm.views import _prepare_stream_history
+        _prepare_stream_history(None, [])
+        mock_build.assert_not_called()
+
+
+class PersistStreamSessionTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="persist-stream@example.com",
+            name="Persist User",
+            password="secret",
+            status="verified",
+        )
+
+    def test_positive_creates_new_session_when_none(self):
+        from llm.views import _persist_and_finalize_stream
+        session = _persist_and_finalize_stream(self.user, None, "Hello", "Response")
+        self.assertIsNotNone(session)
+        self.assertEqual(Session.objects.filter(owner=self.user).count(), 1)
+
+    def test_positive_reuses_existing_session(self):
+        from llm.views import _persist_and_finalize_stream
+        existing = Session.objects.create(owner=self.user, title="Existing")
+        session = _persist_and_finalize_stream(self.user, existing, "Hello", "Response")
+        self.assertEqual(session.id, existing.id)
+        self.assertEqual(Session.objects.filter(owner=self.user).count(), 1)
+
+    def test_positive_persists_user_and_assistant_messages(self):
+        from llm.views import _persist_and_finalize_stream
+        session = _persist_and_finalize_stream(self.user, None, "Hello", "World")
+        roles = list(session.messages.values_list("role", flat=True))
+        self.assertIn("user", roles)
+        self.assertIn("assistant", roles)
+
+    def test_edge_assistant_message_content_matches_reply(self):
+        from llm.views import _persist_and_finalize_stream
+        session = _persist_and_finalize_stream(self.user, None, "Q", "Answer text")
+        assistant_msg = session.messages.filter(role="assistant").first()
+        self.assertEqual(assistant_msg.content, "Answer text")

--- a/backend/llm/views.py
+++ b/backend/llm/views.py
@@ -771,11 +771,30 @@ def send_message(request):
     return Response(response_serializer.data)
 
 
+def _build_sse_event(data: dict) -> str:
+    return f"data: {json.dumps(data)}\n\n"
+
+
+def _prepare_stream_history(session, history: list) -> list:
+    if session is None:
+        return history
+    prepared = build_history_with_summary(session, history)
+    return _inject_file_context_if_available(session, prepared)
+
+
+def _persist_and_finalize_stream(user, session, message: str, reply: str):
+    with transaction.atomic():
+        if session is None:
+            title = generate_session_title_from_message(message)
+            session = create_session_for_user(user, title=title)
+        append_user_message(session, message)
+        append_assistant_message(session, reply)
+    return session
+
+
 def _build_stream_event_generator(request, session, history, message):
     reply_chunks = []
-
-    prepared_history = build_history_with_summary(session, history) if session is not None else history
-    prepared_history = _inject_file_context_if_available(session, prepared_history)
+    prepared_history = _prepare_stream_history(session, history)
 
     try:
         stream = generate_streaming_chat_response(prepared_history)
@@ -784,18 +803,18 @@ def _build_stream_event_generator(request, session, history, message):
                 stream.close()
                 return
             reply_chunks.append(chunk)
-            yield f"data: {json.dumps({'chunk': chunk})}\n\n"
+            yield _build_sse_event({'chunk': chunk})
     except OpenAIConfigurationError:
         raise
     except OpenAIServiceError:
-        yield f"data: {json.dumps({'error': UPSTREAM_FAILURE_DETAIL})}\n\n"
+        yield _build_sse_event({'error': UPSTREAM_FAILURE_DETAIL})
         yield _SSE_DONE
         return
     except GeneratorExit:
         return
     except Exception:
         logger.exception("Unexpected error during streaming send_message.")
-        yield f"data: {json.dumps({'error': INTERNAL_FAILURE_DETAIL})}\n\n"
+        yield _build_sse_event({'error': INTERNAL_FAILURE_DETAIL})
         yield _SSE_DONE
         return
 
@@ -803,14 +822,8 @@ def _build_stream_event_generator(request, session, history, message):
     if not reply:
         return
 
-    with transaction.atomic():
-        if session is None:
-            title = generate_session_title_from_message(message)
-            session = create_session_for_user(request.user, title=title)
-        append_user_message(session, message)
-        append_assistant_message(session, reply)
-
-    yield f"data: {json.dumps({'session_id': str(session.id), 'done': True})}\n\n"
+    session = _persist_and_finalize_stream(request.user, session, message, reply)
+    yield _build_sse_event({'session_id': str(session.id), 'done': True})
     yield _SSE_DONE
 
 


### PR DESCRIPTION
## Summary
This pull request introduces several refactorings and new tests to improve the maintainability, test coverage, and clarity of the codebase, particularly around message serializers, OpenAI client utilities, and streaming view helpers. The most significant changes are grouped below.

### Serializer Refactoring and Validation Improvements

* Introduced a new base serializer class `BaseMessageRequestSerializer` to unify shared logic for message-based requests, and updated `SendMessageRequestSerializer` and `StreamSendMessageRequestSerializer` to inherit from it. This ensures consistent validation and code reuse for message fields. [[1]](diffhunk://#diff-6cacf14ed145792e6e44fb1c8844d6acb0d229474d7dc5c2676bfd13f107a0e3L239-L241) [[2]](diffhunk://#diff-6cacf14ed145792e6e44fb1c8844d6acb0d229474d7dc5c2676bfd13f107a0e3L254-R258)
* Added comprehensive unit tests for the new base serializer, including validation of blank/missing messages and optional fields.

### OpenAI Client Utility Refactoring

* Refactored the `_normalize_chat_message_content` logic by extracting the text extraction functionality into a new helper function `_extract_text_from_content_item`, improving modularity and testability.
* Added targeted unit tests for `_extract_text_from_content_item` covering various input scenarios and edge cases.

### Streaming View Helper Refactoring and Testing

* Refactored streaming view helper logic by extracting SSE event formatting, history preparation, and session persistence into dedicated helper functions: `_build_sse_event`, `_prepare_stream_history`, and `_persist_and_finalize_stream`. Updated the main streaming generator to use these helpers. [[1]](diffhunk://#diff-42776f2345d375ce07bf9e0eac7981865d86e4e48c91398a2e674b42397a11f6R774-R797) [[2]](diffhunk://#diff-42776f2345d375ce07bf9e0eac7981865d86e4e48c91398a2e674b42397a11f6L787-R826)
* Added comprehensive tests for the new streaming view helpers, ensuring correct SSE formatting, session/message persistence, and history preparation behavior.

### Minor Improvements

* Updated test imports to include `SimpleTestCase` where appropriate. [[1]](diffhunk://#diff-af41b0981640a1c100b80d1a98c92ec600d723f8bc3194eec29ce2891a055a93L4-R4) [[2]](diffhunk://#diff-7582d79c5b1bb2e2ba6d934f5ece17bb860b555bc8ccf46c9f2ae7427b07c1f8R9)
<!--- Briefly explain what this PR does and why-->

## How to Test

<!--- Steps to manually test or verify functionality-->

1. Run automatic tests:
```
coverage run manage.py test llm.tests
```
2. All run Passed

## Related Issues

<!--- Link to relevant issues, e.g., Closes #123, Fixes #456, Related to #789 -->

## Author Checklist

- [X] Code follows team coding standards and style guide
- [X] Self-reviewed the code changes
- [X] Added/updated tests for new functionality
- [X] All tests pass locally
- [X] Code is properly documented
- [X] Synced with latest `main` branch
- [X] PR title follows conventional commit format
- [X] Meaningful commit messages used

## Additional Notes

<!-- Any additional context, screenshots, or information reviewers should know -->

## Type of task

<!--- Please checklist options that are relevant -->

- [ ] Data Processing (for tasks involving data handling or manipulation)
- [ ] Model Training (for tasks involving model training)
- [ ] API Development (for developing or serving model via API)
- [ ] UI Development (for developing or improving user interface)
- [ ] Testing (for writing or updating tests)
- [ ] Debugging (for fixing errors or investigating issues)
- [X] Refactor (for code improvements without changing functionality)
- [ ] Performance Improvement / Optimization (for optimizations related to speed or efficiency)
- [ ] Security (for tasks related to security updates or patches)
- [ ] Documentation (for updating or improving documentation)
- [ ] Monitoring (for adding or updating monitoring capabilities)
- [ ] All

## Reviewer(s)

<!--- Please add the names or GitHub usernames of the reviewers -->

- [ ] @username1
- [ ] @username2
- [ ] @username3
